### PR TITLE
fix spelling mistake 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To start the development server, run:
 
 ```bash
 $ pnpm install # initially and always after changing package dependencies
-$ pnp dev      # starts dev server
+$ pnpm dev      # starts dev server
   VITE v4.3.9  ready in 832 ms
 
   ➜  Local:   http://localhost:5173/


### PR DESCRIPTION
PR contains a fix of a spelling mistake in the README.md (`pnp dev` -> `pnpm dev`)