### PR TITLE
Don't include the map view's padding during printing (#311)

### DIFF
--- a/.changeset/six-phones-invite.md
+++ b/.changeset/six-phones-invite.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/printing": patch
+---
+
+Don't include the map view's padding by default (see open-pioneer/trails-openlayers-base-packages#311)

--- a/src/packages/printing/Printing.test.tsx
+++ b/src/packages/printing/Printing.test.tsx
@@ -13,6 +13,7 @@ import * as PrintingControllerModule from "./PrintingController";
 
 const setFileFormatSpy = vi.fn();
 const setTitleSpy = vi.fn();
+const setViewPaddingSpy = vi.fn();
 const handleMapExportSpy = vi.fn(() => Promise.resolve());
 const notifySpy = vi.fn();
 
@@ -20,6 +21,7 @@ const notifySpy = vi.fn();
 class MockPrintingController {
     setTitle = setTitleSpy;
     setFileFormat = setFileFormatSpy;
+    setViewPadding = setViewPaddingSpy;
     handleMapExport = handleMapExportSpy;
 
     destroy() {}

--- a/src/packages/printing/Printing.tsx
+++ b/src/packages/printing/Printing.tsx
@@ -17,7 +17,7 @@ import { PackageIntl } from "@open-pioneer/runtime";
 import { useIntl, useService } from "open-pioneer:react-hooks";
 import { FC, useEffect, useState } from "react";
 import { FileFormatType, PrintingController } from "./PrintingController";
-import { PrintingService } from "./index";
+import { ViewPaddingBehavior, type PrintingService } from "./index";
 
 const LOG = createLogger("printing");
 
@@ -29,6 +29,13 @@ export interface PrintingProps extends CommonComponentProps {
      * The id of the map.
      */
     mapId: string;
+
+    /**
+     * Whether to respect the map's padding when printing (default: `"auto"`).
+     *
+     * See also {@link ViewPaddingBehavior}.
+     */
+    viewPadding?: ViewPaddingBehavior;
 }
 
 /**
@@ -37,7 +44,7 @@ export interface PrintingProps extends CommonComponentProps {
 export const Printing: FC<PrintingProps> = (props) => {
     const intl = useIntl();
 
-    const { mapId } = props;
+    const { mapId, viewPadding = "auto" } = props;
     const { containerProps } = useCommonComponentProps("printing", props);
     const [selectedFileFormat, setSelectedFileFormat] = useState<FileFormatType>("pdf");
     const [title, setTitle] = useState<string>("");
@@ -47,8 +54,7 @@ export const Printing: FC<PrintingProps> = (props) => {
     const notifier = useService<NotificationService>("notifier.NotificationService");
 
     const { map } = useMapModel(mapId);
-
-    const controller = useController(map, intl, printingService);
+    const controller = useController(map, intl, printingService, viewPadding);
 
     useEffect(() => {
         controller?.setFileFormat(selectedFileFormat);
@@ -136,7 +142,8 @@ export const Printing: FC<PrintingProps> = (props) => {
 function useController(
     map: MapModel | undefined,
     intl: PackageIntl,
-    printingService: PrintingService
+    printingService: PrintingService,
+    viewPadding: ViewPaddingBehavior
 ) {
     const [controller, setController] = useState<PrintingController | undefined>(undefined);
 
@@ -155,5 +162,10 @@ function useController(
             setController(undefined);
         };
     }, [map, intl, printingService]);
+
+    useEffect(() => {
+        controller?.setViewPadding(viewPadding);
+    }, [controller, viewPadding]);
+
     return controller;
 }

--- a/src/packages/printing/Printing.tsx
+++ b/src/packages/printing/Printing.tsx
@@ -17,7 +17,7 @@ import { PackageIntl } from "@open-pioneer/runtime";
 import { useIntl, useService } from "open-pioneer:react-hooks";
 import { FC, useEffect, useState } from "react";
 import { FileFormatType, PrintingController } from "./PrintingController";
-import { ViewPaddingBehavior, type PrintingService } from "./index";
+import type { ViewPaddingBehavior, PrintingService } from "./index";
 
 const LOG = createLogger("printing");
 
@@ -31,7 +31,7 @@ export interface PrintingProps extends CommonComponentProps {
     mapId: string;
 
     /**
-     * Whether to respect the map's padding when printing (default: `"auto"`).
+     * Whether to respect the map view's padding when printing (default: `"auto"`).
      *
      * See also {@link ViewPaddingBehavior}.
      */

--- a/src/packages/printing/PrintingController.ts
+++ b/src/packages/printing/PrintingController.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import OlMap from "ol/Map";
-import { PrintingService, PrintResult } from "./index";
+import { PrintingService, PrintResult, ViewPaddingBehavior } from "./index";
 import { canvasToPng, createBlockUserOverlay } from "./utils";
 import { Resource } from "@open-pioneer/core";
 
@@ -16,6 +16,7 @@ export class PrintingController {
     private i18n: I18n;
 
     private printingService: PrintingService;
+    private viewPadding: ViewPaddingBehavior | undefined;
 
     private printMap: PrintResult | undefined = undefined;
     private overlay: Resource | undefined = undefined;
@@ -38,6 +39,10 @@ export class PrintingController {
         this.fileFormat = format;
     }
 
+    setViewPadding(padding: ViewPaddingBehavior) {
+        this.viewPadding = padding;
+    }
+
     async handleMapExport() {
         if (!this.olMap || !this.fileFormat) {
             return;
@@ -46,7 +51,8 @@ export class PrintingController {
         try {
             this.begin();
             this.printMap = await this.printingService.printMap(this.olMap, {
-                blockUserInteraction: false
+                blockUserInteraction: false,
+                viewPadding: this.viewPadding
             });
             const canvas = this.printMap.getCanvas();
             if (canvas) {

--- a/src/packages/printing/PrintingServiceImpl.ts
+++ b/src/packages/printing/PrintingServiceImpl.ts
@@ -125,8 +125,8 @@ export class PrintJob {
         }
 
         // Position the scale bar manually.
-        // The 50px should be plenty to avoid overlapping with openlayers attributions on most cases.
-        // Additionally take the view padding into account (if behavior is 'auto').
+        // The 50px should be plenty to avoid overlapping with open layers attributions on most cases.
+        // Additionally, take the view padding into account (if behavior is 'auto').
         let bottom = 50;
         let left = 8;
         if (this.viewPadding === "auto") {
@@ -220,9 +220,8 @@ export class PrintJob {
         newCanvas.width = width - padding.left - padding.right;
         newCanvas.height = height - padding.top - padding.bottom;
 
-        const ctx = canvas.getContext("2d");
         const newCtx = newCanvas.getContext("2d");
-        if (!ctx || !newCtx) {
+        if (!newCtx) {
             throw new Error("Failed to get a canvas context");
         }
 

--- a/src/packages/printing/PrintingServiceImpl.ts
+++ b/src/packages/printing/PrintingServiceImpl.ts
@@ -205,20 +205,30 @@ export class PrintJob {
             });
     }
 
-    private removePadding(canvas: HTMLCanvasElement, padding: ViewPadding): HTMLCanvasElement {
+    private removePadding(canvas: HTMLCanvasElement, rawPadding: ViewPadding): HTMLCanvasElement {
+        // The canvas returned by html2canvas is scaled by the device pixel ratio.
+        // The padding needs to be adjusted (because its in css pixels).
+        const dpr = window.devicePixelRatio || 1;
+        const dprPadding = {
+            top: rawPadding.top * dpr,
+            right: rawPadding.right * dpr,
+            bottom: rawPadding.bottom * dpr,
+            left: rawPadding.left * dpr
+        };
+
         if (
-            padding.left === 0 &&
-            padding.right === 0 &&
-            padding.top === 0 &&
-            padding.bottom === 0
+            dprPadding.left === 0 &&
+            dprPadding.right === 0 &&
+            dprPadding.top === 0 &&
+            dprPadding.bottom === 0
         ) {
             return canvas;
         }
 
         const { width, height } = canvas;
         const newCanvas = document.createElement("canvas");
-        newCanvas.width = width - padding.left - padding.right;
-        newCanvas.height = height - padding.top - padding.bottom;
+        newCanvas.width = width - dprPadding.left - dprPadding.right;
+        newCanvas.height = height - dprPadding.top - dprPadding.bottom;
 
         const newCtx = newCanvas.getContext("2d");
         if (!newCtx) {
@@ -227,8 +237,8 @@ export class PrintJob {
 
         newCtx.drawImage(
             canvas,
-            padding.left,
-            padding.top,
+            dprPadding.left,
+            dprPadding.top,
             newCanvas.width,
             newCanvas.height,
             0,

--- a/src/packages/printing/README.md
+++ b/src/packages/printing/README.md
@@ -64,7 +64,14 @@ const printResult = await printingService.printMap(map, {
 ### Printed elements
 
 The printed map contains all map elements, visible layers, scale-bar and a title. If the user does not enter a title, the map is printed without title.
-To prevent custom elements from showing in the printed map, add the classname `printing-hide` to the elements.
+To prevent custom elements from showing in the printed map, add the CSS class name `printing-hide` to the elements.
+
+### View padding
+
+The printing widget and the printing service will by default respect the map's current view `padding` (see OpenLayers [View class](https://openlayers.org/en/latest/apidoc/module-ol_View-View.html)).
+This means that padded regions (a border on every side) will _not_ be included in the printed result.
+
+To ignore the view padding when printing the map, you can pass `viewPadding: "ignore"` to the printing service or the printing component.
 
 ## Known issues
 

--- a/src/packages/printing/index.ts
+++ b/src/packages/printing/index.ts
@@ -22,13 +22,13 @@ export interface PrintingOptions {
     overlayText?: string;
 
     /**
-     * Whether to respect the map's padding when printing (default: `"auto"`).
+     * Whether to respect the map view's padding when printing (default: `"auto"`).
      */
     viewPadding?: ViewPaddingBehavior;
 }
 
 /**
- * Whether to respect the map's padding when printing.
+ * Whether to respect the map view's padding when printing.
  *
  * - `"auto"`: Respect the map's current viewPadding.
  *   Padded regions of the map will _not_ be included in the print result.

--- a/src/packages/printing/index.ts
+++ b/src/packages/printing/index.ts
@@ -20,7 +20,21 @@ export interface PrintingOptions {
      * This option can be used to customize the text content of the overlay (if enabled).
      */
     overlayText?: string;
+
+    /**
+     * Whether to respect the map's padding when printing (default: `"auto"`).
+     */
+    viewPadding?: ViewPaddingBehavior;
 }
+
+/**
+ * Whether to respect the map's padding when printing.
+ *
+ * - `"auto"`: Respect the map's current viewPadding.
+ *   Padded regions of the map will _not_ be included in the print result.
+ * - `"ignore"`: Ignore the map's viewPadding. The entire map will be printed.
+ */
+export type ViewPaddingBehavior = "auto" | "ignore";
 
 /**
  * The printing service provides an image of a map as a canvas element or a data URL for a PNG image.

--- a/src/packages/printing/styles.css
+++ b/src/packages/printing/styles.css
@@ -21,3 +21,10 @@
     font-size: 1.5em;
     text-align: center;
 }
+
+/* more specific than the open layers selector */
+.printing-scale-bar.ol-scale-bar {
+    /* these variables are set in the PrintingService and may include the map view's padding */
+    left: var(--printing-scale-bar-left);
+    bottom: var(--printing-scale-bar-bottom);
+}


### PR DESCRIPTION
This PR updates the printing package.
The printing component (and the printing service) will now _exclude_ the view's padding from the result by default.

This can be configured by using the `viewPadding` property / option. Supported values are

- `auto` (the default): exclude the view's padding from the printed result
- `ignore`: ignore the view's padding during printing (print the entire map)

Feedback: rename `auto` to something else? include/exclude for example?

Fixes #311 