### PR TITLE
Fix/issues/320

### DIFF
--- a/.changeset/nasty-hats-laugh.md
+++ b/.changeset/nasty-hats-laugh.md
@@ -1,0 +1,6 @@
+---
+"@open-pioneer/basemap-switcher": patch
+"@open-pioneer/selection": patch
+---
+
+issue #320

--- a/.changeset/nasty-hats-laugh.md
+++ b/.changeset/nasty-hats-laugh.md
@@ -3,4 +3,4 @@
 "@open-pioneer/selection": patch
 ---
 
-issue #320
+Open select-menu on enter (fixes issue [#320](https://github.com/open-pioneer/trails-openlayers-base-packages/issues/320))

--- a/src/packages/basemap-switcher/BasemapSwitcher.tsx
+++ b/src/packages/basemap-switcher/BasemapSwitcher.tsx
@@ -3,7 +3,7 @@
 import { Box, Flex, Tooltip, useToken } from "@open-pioneer/chakra-integration";
 import { Layer, MapModel, useMapModel } from "@open-pioneer/map";
 import { useIntl } from "open-pioneer:react-hooks";
-import React, { FC, useCallback, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { FC, useCallback, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
     chakraComponents,
     ChakraStylesConfig,
@@ -14,6 +14,7 @@ import {
 } from "chakra-react-select";
 import { CommonComponentProps, useCommonComponentProps, useEvent } from "@open-pioneer/react-utils";
 import { FiAlertTriangle } from "react-icons/fi";
+import { KeyboardEvent } from "react";
 
 /*
     Exported for tests. Feels a bit hacky but should be fine for now.
@@ -113,7 +114,7 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
             SingleValue: BasemapSelectValue
         };
     }, []);
-    const keyDown = useEvent((event: React.KeyboardEvent<HTMLDivElement>) => {
+    const keyDown = useEvent((event: KeyboardEvent<HTMLDivElement>) => {
         //if the menu is already open, do noting
         if (!isOpenSelect && event.key === "Enter") {
             setIsOpenSelect(true);

--- a/src/packages/basemap-switcher/BasemapSwitcher.tsx
+++ b/src/packages/basemap-switcher/BasemapSwitcher.tsx
@@ -3,14 +3,14 @@
 import { Box, Flex, Tooltip, useToken } from "@open-pioneer/chakra-integration";
 import { Layer, MapModel, useMapModel } from "@open-pioneer/map";
 import { useIntl } from "open-pioneer:react-hooks";
-import { FC, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { FC, useCallback, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
-    Select,
-    OptionProps,
-    SingleValueProps,
     chakraComponents,
     ChakraStylesConfig,
-    GroupBase
+    GroupBase,
+    OptionProps,
+    Select,
+    SingleValueProps
 } from "chakra-react-select";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { FiAlertTriangle } from "react-icons/fi";
@@ -86,6 +86,7 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
     const { map } = useMapModel(mapId);
     const baseLayers = useBaseLayers(map);
     const chakraStyles = useChakraStyles();
+    const [isOpenSelect, setIsOpenSelect] = useState(false);
 
     const activateLayer = (layerId: string) => {
         map?.layers.activateBaseLayer(layerId === NO_BASEMAP_ID ? undefined : layerId);
@@ -112,6 +113,16 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
             SingleValue: BasemapSelectValue
         };
     }, []);
+    const keyDownFunction = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        //if the menu is already open, do noting
+        if (isOpenSelect) {
+            return;
+        }
+        switch (event.key) {
+            case "Enter":
+                setIsOpenSelect(true);
+        }
+    };
 
     return (
         <Box {...containerProps}>
@@ -139,6 +150,10 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
                     isOptionDisabled={(option) => option?.layer?.loadState === "error"}
                     components={components}
                     chakraStyles={chakraStyles}
+                    onKeyDown={keyDownFunction}
+                    menuIsOpen={isOpenSelect}
+                    onMenuOpen={() => setIsOpenSelect(true)}
+                    onMenuClose={() => setIsOpenSelect(false)}
                 />
             ) : null}
         </Box>

--- a/src/packages/basemap-switcher/BasemapSwitcher.tsx
+++ b/src/packages/basemap-switcher/BasemapSwitcher.tsx
@@ -3,7 +3,7 @@
 import { Box, Flex, Tooltip, useToken } from "@open-pioneer/chakra-integration";
 import { Layer, MapModel, useMapModel } from "@open-pioneer/map";
 import { useIntl } from "open-pioneer:react-hooks";
-import { FC, useCallback, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import React, { FC, useCallback, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
     chakraComponents,
     ChakraStylesConfig,
@@ -12,7 +12,7 @@ import {
     Select,
     SingleValueProps
 } from "chakra-react-select";
-import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
+import { CommonComponentProps, useCommonComponentProps, useEvent } from "@open-pioneer/react-utils";
 import { FiAlertTriangle } from "react-icons/fi";
 
 /*
@@ -113,16 +113,12 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
             SingleValue: BasemapSelectValue
         };
     }, []);
-    const keyDownFunction = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const keyDown = useEvent((event: React.KeyboardEvent<HTMLDivElement>) => {
         //if the menu is already open, do noting
-        if (isOpenSelect) {
-            return;
+        if (!isOpenSelect && event.key === "Enter") {
+            setIsOpenSelect(true);
         }
-        switch (event.key) {
-            case "Enter":
-                setIsOpenSelect(true);
-        }
-    };
+    });
 
     return (
         <Box {...containerProps}>
@@ -150,7 +146,7 @@ export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
                     isOptionDisabled={(option) => option?.layer?.loadState === "error"}
                     components={components}
                     chakraStyles={chakraStyles}
-                    onKeyDown={keyDownFunction}
+                    onKeyDown={keyDown}
                     menuIsOpen={isOpenSelect}
                     onMenuOpen={() => setIsOpenSelect(true)}
                     onMenuClose={() => setIsOpenSelect(false)}

--- a/src/packages/selection/Selection.tsx
+++ b/src/packages/selection/Selection.tsx
@@ -27,7 +27,7 @@ import {
 } from "chakra-react-select";
 import { Geometry } from "ol/geom";
 import { useIntl, useService } from "open-pioneer:react-hooks";
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { FiAlertTriangle } from "react-icons/fi";
 import { DragController } from "./DragController";
 import { SelectionController } from "./SelectionController";
@@ -138,6 +138,7 @@ export const Selection: FC<SelectionProps> = (props) => {
         onSelectionComplete
     );
     const chakraStyles = useChakraStyles();
+    const [isOpenSelect, setIsOpenSelect] = useState(false);
 
     /**
      * Method to build Option-Array from the supported selection methods for the selection-method react-select
@@ -216,6 +217,12 @@ export const Selection: FC<SelectionProps> = (props) => {
         });
         return () => handle.destroy();
     }, [currentSource, setDragControllerActive, intl]);
+    const keyDown = useEvent((event: React.KeyboardEvent<HTMLDivElement>) => {
+        //if the menu is already open, do noting
+        if (!isOpenSelect && event.key === "Enter") {
+            setIsOpenSelect(true);
+        }
+    });
 
     return (
         <VStack {...containerProps} spacing={2}>
@@ -256,6 +263,10 @@ export const Selection: FC<SelectionProps> = (props) => {
                             : "")
                     }
                     chakraStyles={chakraStyles}
+                    onKeyDown={keyDown}
+                    menuIsOpen={isOpenSelect}
+                    onMenuOpen={() => setIsOpenSelect(true)}
+                    onMenuClose={() => setIsOpenSelect(false)}
                 />
             </FormControl>
         </VStack>

--- a/src/packages/selection/Selection.tsx
+++ b/src/packages/selection/Selection.tsx
@@ -27,11 +27,12 @@ import {
 } from "chakra-react-select";
 import { Geometry } from "ol/geom";
 import { useIntl, useService } from "open-pioneer:react-hooks";
-import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { FiAlertTriangle } from "react-icons/fi";
 import { DragController } from "./DragController";
 import { SelectionController } from "./SelectionController";
 import { SelectionResult, SelectionSource, SelectionSourceStatusObject } from "./api";
+import { KeyboardEvent } from "react";
 
 /**
  * Properties supported by the {@link Selection} component.
@@ -217,7 +218,7 @@ export const Selection: FC<SelectionProps> = (props) => {
         });
         return () => handle.destroy();
     }, [currentSource, setDragControllerActive, intl]);
-    const keyDown = useEvent((event: React.KeyboardEvent<HTMLDivElement>) => {
+    const keyDown = useEvent((event: KeyboardEvent<HTMLDivElement>) => {
         //if the menu is already open, do noting
         if (!isOpenSelect && event.key === "Enter") {
             setIsOpenSelect(true);


### PR DESCRIPTION
See issue #320 

## Problem
The problem is the different usage of `<Select>` in the different bundles. Printing e.g. uses `"@open-pioneer/chakra-integration"`, while the basemapswitcher uses `"chakra-react-select"`. The chakra select uses a `HTMLDivElement` element as base structure, while the open-pioneer version is a `HTMLSelectElement`. Therefore the standard keydown events behave different.

The usage of a reference with `useRef` is possible, but because of the base as `HTMLDivElement`, it is not possible to check if the select element menu is already open. So the "Enter" key let's you open the menu, but it leads to the behaviour, that the menu stays open after selecting an element with "Enter".

## Solution 
With the usage of a select state, i could copy the behaviour of the "general" select element. It behaves like the other `<Select>` elements.

[x] BasemapSwitcher Select fixed
[x] Selection Select fixed