### PR TITLE
[Zoom] Respect zoom limits #356

### DIFF
--- a/.changeset/eleven-news-move.md
+++ b/.changeset/eleven-news-move.md
@@ -1,5 +1,6 @@
 ---
-"@open-pioneer/map-navigation": minor
+"@open-pioneer/map-navigation": patch
 ---
 
-issue 356 -- respect zoom limits
+Don't attempt to zoom past configured zoom limits (#356).
+As a side effect of this change, clicks on the zoom in/out buttons are ignored during the brief animation period (currently 200ms).

--- a/.changeset/eleven-news-move.md
+++ b/.changeset/eleven-news-move.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map-navigation": minor
+---
+
+issue 356 -- respect zoom limits

--- a/src/packages/map-navigation/README.md
+++ b/src/packages/map-navigation/README.md
@@ -30,14 +30,6 @@ You can also use the generic `Zoom` component:
 <Zoom mapId="map_id" zoomDirection="in" />
 ```
 
-If you don't want to allow zooming, while the animation is not finished,
-you can prohibit it by setting the `disableWhileAnimating` prop to `true`.
-This is also interesting if you want the user to only zoom between static scales and not in between.
-
-```jsx
-<Zoom mapId="map_id" zoomDirection="in" disableWhileAnimating={true} />
-```
-
 ## License
 
 Apache-2.0 (see `LICENSE` file)

--- a/src/packages/map-navigation/README.md
+++ b/src/packages/map-navigation/README.md
@@ -30,6 +30,14 @@ You can also use the generic `Zoom` component:
 <Zoom mapId="map_id" zoomDirection="in" />
 ```
 
+If you don't want to allow zooming, while the animation is not finished,
+you can prohibit it by setting the `disableWhileAnimating` prop to `true`.
+This is also interesting if you want the user to only zoom between static scales and not in between.
+
+```jsx
+<Zoom mapId="map_id" zoomDirection="in" disableWhileAnimating={true} />
+```
+
 ## License
 
 Apache-2.0 (see `LICENSE` file)

--- a/src/packages/map-navigation/Zoom.tsx
+++ b/src/packages/map-navigation/Zoom.tsx
@@ -46,11 +46,6 @@ export interface ZoomProps extends CommonComponentProps, RefAttributes<HTMLButto
      * The button will either zoom in or zoom out depending on this value.
      */
     zoomDirection: "in" | "out";
-
-    /**
-     * Disable the button while the animation is running.
-     */
-    disableZoomBetweenAnimation?: boolean;
 }
 
 /**
@@ -60,7 +55,7 @@ export const Zoom: FC<ZoomProps> = forwardRef(function Zoom(
     props: ZoomProps,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
-    const { mapId, zoomDirection, disableZoomBetweenAnimation } = props;
+    const { mapId, zoomDirection } = props;
     const { map } = useMapModel(mapId);
     const intl = useIntl();
     const [disabled, setDisabled] = useState<boolean>(false);
@@ -69,10 +64,10 @@ export const Zoom: FC<ZoomProps> = forwardRef(function Zoom(
     const { containerProps } = useCommonComponentProps(classNames("zoom", defaultClassName), props);
 
     function zoom() {
-        if (disableZoomBetweenAnimation && disabled) {
+        if (disabled) {
             return;
         }
-        setDisabled(!!disableZoomBetweenAnimation);
+        setDisabled(true);
         const view = map?.olMap.getView();
         let currZoom = view?.getZoom();
 
@@ -91,7 +86,6 @@ export const Zoom: FC<ZoomProps> = forwardRef(function Zoom(
 
     return (
         <ToolButton
-            isDisabled={disabled}
             ref={ref}
             label={buttonLabel}
             icon={buttonIcon}


### PR DESCRIPTION
See #356 

# Reproduce

## Example configuration in MapConfigProviderImpl
```jsx
{
	initialView: {
	  kind: "position",
	  center: { x: 404747, y: 5757920 },
	  zoom: 14
	},
	advanced: {
	  view: {
		maxZoom: 15,
		minZoom: 13,
                constrainResolution: true
	  },
	},
	layers: [
	  new SimpleLayer({
		  title: "OSM",
		  isBaseLayer: true,
		  olLayer: new TileLayer({
			  source: new OSM()
		  })
	  })
	]
};
```
## SimpleDemos

```jsx
<ZoomIn mapId={MAP_ID} disableZoomBetweenAnimation={true} />
<ZoomOut mapId={MAP_ID} disableZoomBetweenAnimation={true} />
```

## Expected Result

1. The Map shouldn't wobble if trying to zoom in/out of the set limits.
2. The user can't zoom between the given resolutions, if `disableZoomBetweenAnimation` is set