### PR TITLE
Feature/coordinate viewer degree extension

### DIFF
--- a/.changeset/slow-bikes-prove.md
+++ b/.changeset/slow-bikes-prove.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/coordinate-viewer": minor
+---
+
+Added option to display geographic coordinates in angle format (DMS) in CoordinateViewer.

--- a/.changeset/slow-bikes-prove.md
+++ b/.changeset/slow-bikes-prove.md
@@ -1,5 +1,9 @@
 ---
-"@open-pioneer/coordinate-viewer": minor
+"@open-pioneer/coordinate-viewer": patch
 ---
 
-Added option to display geographic coordinates in angle format (DMS) in CoordinateViewer.
+Added option to display geographic coordinates in angle format (DMS) in CoordinateViewer:
+
+```jsx
+<CoordinateViewer mapId="map_id" format="degree" />
+```

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -60,12 +60,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Configure git user
-        shell: bash
-        run: |
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1.4.7
         with:

--- a/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
@@ -89,7 +89,7 @@ it("should format coordinates to correct coordinate string for the corresponding
     const coords = [3545.08081, 4543543.009];
 
     const renderCoords = (locale: string, precision = 2) => {
-        return renderHook(() => useCoordinatesString(coords, precision), {
+        return renderHook(() => useCoordinatesString(coords, precision, undefined), {
             wrapper: (props) => <PackageContextProvider {...props} locale={locale} />
         });
     };
@@ -107,9 +107,12 @@ it("should format coordinates to correct coordinate string for the corresponding
 
 it("should format coordinates to correct coordinate string with default precision", async () => {
     const coords = [3545.08081, 4543543.009];
-    const hookDeWithoutPrecision = renderHook(() => useCoordinatesString(coords, undefined), {
-        wrapper: (props) => <PackageContextProvider {...props} locale="de" />
-    });
+    const hookDeWithoutPrecision = renderHook(
+        () => useCoordinatesString(coords, undefined, undefined),
+        {
+            wrapper: (props) => <PackageContextProvider {...props} locale="de" />
+        }
+    );
     expect(hookDeWithoutPrecision.result.current).equals("3.545,0808 4.543.543,0090");
 });
 
@@ -148,6 +151,99 @@ it("should display transformed coordinates if output projection is provided", as
     });
     //851594.11, 6789283.95 (EPSG:3857) == 7.65, 51.94 (EPSG:4326)
     expect(viewerText.textContent).toMatchInlineSnapshot('"7.65 51.94 EPSG:4326"'); //should display WGS84
+});
+
+it("tracks the user's mouse position, when displayProjectionAsDegree={true}", async () => {
+    const { mapId, registry } = await setupMap();
+
+    const injectedServices = createServiceOptions({ registry });
+    render(
+        <PackageContextProvider services={injectedServices}>
+            <MapContainer mapId={mapId} data-testid="map" />
+            <CoordinateViewer
+                mapId={mapId}
+                precision={2}
+                displayProjectionAsDegree={true}
+                data-testid="coordinate-viewer"
+            />
+        </PackageContextProvider>
+    );
+
+    await waitForMapMount("map");
+    const { viewerText } = await waitForCoordinateViewer();
+    expect(viewerText.textContent).toMatchInlineSnapshot('""');
+
+    const map = await registry.expectMapModel(mapId);
+
+    const simulateMove = (x: number, y: number) => {
+        const fakeMoveEvent = new BaseEvent("pointermove");
+        (fakeMoveEvent as any).coordinate = [x, y];
+        map.olMap.dispatchEvent(fakeMoveEvent);
+    };
+
+    // Simple move
+    act(() => {
+        simulateMove(7.65, 51.94);
+    });
+    expect(viewerText.textContent).toMatchInlineSnapshot(
+        '"7°39\'0.00"(E) 51°56\'24.00"(N) EPSG:3857"'
+    );
+
+    // Another move + projection change
+    act(() => {
+        map.olMap.setView(
+            new View({
+                center: [0, 0],
+                zoom: 0,
+                projection: "EPSG:4326"
+            })
+        );
+        simulateMove(42, 1337);
+    });
+    expect(viewerText.textContent).toMatchInlineSnapshot(
+        '"42°0\'0.00"(E) 1337°0\'0.00"(N) EPSG:4326"'
+    );
+});
+
+it("should display transformed coordinates if output projection is provided", async () => {
+    const outputProjection = "EPSG:4326"; //WGS84
+    const asDegree = true;
+    const { mapId, registry } = await setupMap();
+
+    const injectedServices = createServiceOptions({ registry });
+    render(
+        <PackageContextProvider services={injectedServices}>
+            <MapContainer mapId={mapId} data-testid="map" />
+            <CoordinateViewer
+                mapId={mapId}
+                precision={2}
+                displayProjectionCode={outputProjection}
+                displayProjectionAsDegree={asDegree}
+                data-testid="coordinate-viewer"
+            />
+        </PackageContextProvider>
+    );
+
+    await waitForMapMount("map");
+    const { viewerText } = await waitForCoordinateViewer();
+    expect(viewerText.textContent).toMatchInlineSnapshot('""');
+
+    const map = await registry.expectMapModel(mapId);
+
+    const simulateMove = (x: number, y: number) => {
+        const fakeMoveEvent = new BaseEvent("pointermove");
+        (fakeMoveEvent as any).coordinate = [x, y];
+        map.olMap.dispatchEvent(fakeMoveEvent);
+    };
+
+    // Simple move
+    act(() => {
+        simulateMove(851594.11, 6789283.95); //map projection is EPSG:3857 (Web Mercator)
+    });
+    //851594.11, 6789283.95 (EPSG:3857) == 7°39'0.00"(E) 51°56'24.00"(N) (EPSG:4326)
+    expect(viewerText.textContent).toMatchInlineSnapshot(
+        '"7°39\'0.00"(E) 51°56\'24.00"(N) EPSG:4326"'
+    ); //should display WGS84 in Degree
 });
 
 async function waitForCoordinateViewer() {

--- a/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
@@ -163,7 +163,7 @@ it("tracks the user's mouse position, when format is set to 'degree'", async () 
             <CoordinateViewer
                 mapId={mapId}
                 precision={2}
-                format="degrees"
+                format="degree"
                 data-testid="coordinate-viewer"
             />
         </PackageContextProvider>

--- a/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.test.tsx
@@ -153,7 +153,7 @@ it("should display transformed coordinates if output projection is provided", as
     expect(viewerText.textContent).toMatchInlineSnapshot('"7.65 51.94 EPSG:4326"'); //should display WGS84
 });
 
-it("tracks the user's mouse position, when displayProjectionAsDegree={true}", async () => {
+it("tracks the user's mouse position, when format is set to 'degree'", async () => {
     const { mapId, registry } = await setupMap();
 
     const injectedServices = createServiceOptions({ registry });
@@ -163,7 +163,7 @@ it("tracks the user's mouse position, when displayProjectionAsDegree={true}", as
             <CoordinateViewer
                 mapId={mapId}
                 precision={2}
-                displayProjectionAsDegree={true}
+                format="degrees"
                 data-testid="coordinate-viewer"
             />
         </PackageContextProvider>
@@ -205,9 +205,9 @@ it("tracks the user's mouse position, when displayProjectionAsDegree={true}", as
     );
 });
 
-it("should display transformed coordinates if output projection is provided", async () => {
+it("should display transformed coordinates if output projection and format is set to 'degree' is provided", async () => {
     const outputProjection = "EPSG:4326"; //WGS84
-    const asDegree = true;
+    const format = "degree";
     const { mapId, registry } = await setupMap();
 
     const injectedServices = createServiceOptions({ registry });
@@ -218,7 +218,7 @@ it("should display transformed coordinates if output projection is provided", as
                 mapId={mapId}
                 precision={2}
                 displayProjectionCode={outputProjection}
-                displayProjectionAsDegree={asDegree}
+                format={format}
                 data-testid="coordinate-viewer"
             />
         </PackageContextProvider>

--- a/src/packages/coordinate-viewer/CoordinateViewer.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.tsx
@@ -13,6 +13,7 @@ import { useIntl } from "open-pioneer:react-hooks";
 import { FC, useEffect, useState } from "react";
 
 const DEFAULT_PRECISION = 4;
+const DEFAULT_DISPLAY_DEGREE = false;
 
 /**
  * These are special properties for the CoordinateViewer.
@@ -32,13 +33,18 @@ export interface CoordinateViewerProps extends CommonComponentProps {
      * Projection of the coordinates shown in the rendered HTML, does not affect the map projection
      */
     displayProjectionCode?: string;
+
+    /**
+     * Projection of the coordinates shown in the rendered HTML as Degree Format, does not affect the map projection
+     */
+    displayProjectionAsDegree?: boolean;
 }
 
 /**
  * The `CoordinateViewer`component can be used in an app to render the coordinates at the current mouse position.
  */
 export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
-    const { mapId, precision, displayProjectionCode } = props;
+    const { mapId, precision, displayProjectionCode, displayProjectionAsDegree } = props;
     const { containerProps } = useCommonComponentProps("coordinate-viewer", props);
     const { map } = useMapModel(mapId);
     const olMap = map?.olMap;
@@ -48,7 +54,11 @@ export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
         coordinates && displayProjectionCode
             ? transformCoordinates(coordinates, mapProjectionCode, displayProjectionCode)
             : coordinates;
-    const coordinatesString = useCoordinatesString(coordinates, precision);
+    const coordinatesString = useCoordinatesString(
+        coordinates,
+        precision,
+        displayProjectionAsDegree
+    );
     const projectionString = displayProjectionCode ? displayProjectionCode : mapProjectionCode;
     const displayString = coordinatesString ? coordinatesString + " " + projectionString : "";
     return (
@@ -61,10 +71,13 @@ export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
 /* Separate function for easier testing */
 export function useCoordinatesString(
     coordinates: number[] | undefined,
-    precision: number | undefined
+    precision: number | undefined,
+    displayProjectionAsDegree: boolean | undefined
 ): string {
     const intl = useIntl();
-    const coordinatesString = coordinates ? formatCoordinates(coordinates, precision, intl) : "";
+    const coordinatesString = coordinates
+        ? formatCoordinates(coordinates, precision, intl, displayProjectionAsDegree)
+        : "";
     return coordinatesString;
 }
 
@@ -89,26 +102,59 @@ function useCoordinates(map: OlMap | undefined): { coordinates: Coordinate | und
 function formatCoordinates(
     coordinates: number[],
     configuredPrecision: number | undefined,
-    intl: PackageIntl
+    intl: PackageIntl,
+    displayProjectionAsDegree: boolean | undefined
 ) {
     if (coordinates[0] == null || coordinates[1] == null) {
         return "";
     }
 
     const precision = configuredPrecision ?? DEFAULT_PRECISION;
+    const asDegree = displayProjectionAsDegree ?? DEFAULT_DISPLAY_DEGREE;
     const [x, y] = coordinates;
 
-    const xString = intl.formatNumber(x, {
-        maximumFractionDigits: precision,
-        minimumFractionDigits: precision
-    });
-    const yString = intl.formatNumber(y, {
+    if (asDegree && isFinite(x) && isFinite(y)) {
+        const [xHour, xMin, xSek] = toDegree(x, intl, precision);
+        const [yHour, yMin, ySek] = toDegree(y, intl, precision);
+
+        const xString = `${Math.abs(xHour)}°${xMin}'${xSek}"${0 <= xHour ? "(E)" : "(W)"}`;
+        const yString = `${Math.abs(yHour)}°${yMin}'${ySek}"${0 <= yHour ? "(N)" : "(S)"}`;
+
+        const coordinatesString = xString + " " + yString;
+        return coordinatesString;
+    } else {
+        const xString = intl.formatNumber(x, {
+            maximumFractionDigits: precision,
+            minimumFractionDigits: precision
+        });
+        const yString = intl.formatNumber(y, {
+            maximumFractionDigits: precision,
+            minimumFractionDigits: precision
+        });
+        const coordinatesString = xString + " " + yString;
+        return coordinatesString;
+    }
+}
+
+function toDegree(
+    coordPart: number,
+    intl: PackageIntl,
+    precision: number
+): [number, number, string] {
+    const cHour = Math.floor(coordPart);
+    const cNach = coordPart - cHour;
+
+    const cMin = Math.floor(60 * cNach);
+
+    const cMinNach = 60 * cNach - cMin;
+
+    const cSek = 60 * cMinNach;
+    const cSekRounded = intl.formatNumber(cSek, {
         maximumFractionDigits: precision,
         minimumFractionDigits: precision
     });
 
-    const coordinatesString = xString + " " + yString;
-    return coordinatesString;
+    return [cHour, cMin, cSekRounded];
 }
 
 function transformCoordinates(

--- a/src/packages/coordinate-viewer/CoordinateViewer.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.tsx
@@ -13,7 +13,7 @@ import { useIntl } from "open-pioneer:react-hooks";
 import { FC, useEffect, useState } from "react";
 
 const DEFAULT_PRECISION = 4;
-const DEFAULT_DISPLAY_DEGREE = false;
+const DEFAULT_DISPLAY_FORMAT = "decimal";
 
 /**
  * These are special properties for the CoordinateViewer.
@@ -37,14 +37,14 @@ export interface CoordinateViewerProps extends CommonComponentProps {
     /**
      * Projection of the coordinates shown in the rendered HTML as Degree Format, does not affect the map projection
      */
-    displayProjectionAsDegree?: boolean;
+    format?: string;
 }
 
 /**
  * The `CoordinateViewer`component can be used in an app to render the coordinates at the current mouse position.
  */
 export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
-    const { mapId, precision, displayProjectionCode, displayProjectionAsDegree } = props;
+    const { mapId, precision, displayProjectionCode, format } = props;
     const { containerProps } = useCommonComponentProps("coordinate-viewer", props);
     const { map } = useMapModel(mapId);
     const olMap = map?.olMap;
@@ -54,11 +54,7 @@ export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
         coordinates && displayProjectionCode
             ? transformCoordinates(coordinates, mapProjectionCode, displayProjectionCode)
             : coordinates;
-    const coordinatesString = useCoordinatesString(
-        coordinates,
-        precision,
-        displayProjectionAsDegree
-    );
+    const coordinatesString = useCoordinatesString(coordinates, precision, format);
     const projectionString = displayProjectionCode ? displayProjectionCode : mapProjectionCode;
     const displayString = coordinatesString ? coordinatesString + " " + projectionString : "";
     return (
@@ -72,11 +68,11 @@ export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
 export function useCoordinatesString(
     coordinates: number[] | undefined,
     precision: number | undefined,
-    displayProjectionAsDegree: boolean | undefined
+    format: string | undefined
 ): string {
     const intl = useIntl();
     const coordinatesString = coordinates
-        ? formatCoordinates(coordinates, precision, intl, displayProjectionAsDegree)
+        ? formatCoordinates(coordinates, precision, intl, format)
         : "";
     return coordinatesString;
 }
@@ -103,17 +99,17 @@ function formatCoordinates(
     coordinates: number[],
     configuredPrecision: number | undefined,
     intl: PackageIntl,
-    displayProjectionAsDegree: boolean | undefined
+    configuredFormat: string | undefined
 ) {
     if (coordinates[0] == null || coordinates[1] == null) {
         return "";
     }
 
     const precision = configuredPrecision ?? DEFAULT_PRECISION;
-    const asDegree = displayProjectionAsDegree ?? DEFAULT_DISPLAY_DEGREE;
+    const format = configuredFormat ?? DEFAULT_DISPLAY_FORMAT;
     const [x, y] = coordinates;
 
-    if (asDegree && isFinite(x) && isFinite(y)) {
+    if (format === "degree" || (format === "degrees" && isFinite(x) && isFinite(y))) {
         const [xHour, xMin, xSek] = toDegree(x, intl, precision);
         const [yHour, yMin, ySek] = toDegree(y, intl, precision);
 

--- a/src/packages/coordinate-viewer/README.md
+++ b/src/packages/coordinate-viewer/README.md
@@ -22,6 +22,12 @@ To show the coordinates in a specific projection, set the optional `displayProje
 <CoordinateViewer mapId="map_id" displayProjectionCode="EPSG:4326" />
 ```
 
+To show the coordinates in a specific coordinate format, set the optional `format` property (default: `decimal`):
+
+```jsx
+<CoordinateViewer mapId="map_id" format="degrees" />
+```
+
 ## License
 
 Apache-2.0 (see `LICENSE` file)

--- a/src/packages/coordinate-viewer/README.md
+++ b/src/packages/coordinate-viewer/README.md
@@ -25,7 +25,7 @@ To show the coordinates in a specific projection, set the optional `displayProje
 To show the coordinates in a specific coordinate format, set the optional `format` property (default: `decimal`):
 
 ```jsx
-<CoordinateViewer mapId="map_id" format="degrees" />
+<CoordinateViewer mapId="map_id" format="degree" />
 ```
 
 ## License


### PR DESCRIPTION
This pull request adds a new feature to the CoordinateViewer component that allows users to display geographic coordinates in degrees, minutes, and seconds (DMS) format instead of the default decimal format. The new behavior is controlled by the displayProjectionAsDegree boolean property. If this property is set to true, coordinates are displayed in the DMS format; otherwise, the default decimal format is used. This option is only possible for geographic coordinate systems and make sense for coordinate systems like EPSG:4326.