### PR TITLE
add option to retrieve child layers from layer collection

### DIFF
--- a/.changeset/short-jars-build.md
+++ b/.changeset/short-jars-build.md
@@ -1,0 +1,27 @@
+---
+"@open-pioneer/map": minor
+---
+
+Add option to retrieve child layers from `LayerCollection` in `@open-pioneer/map`
+
+Introduce option `includeChildLayers` for `getOperationLayers` and `getAllLayers` to optionally include (nested) children (sublayers and layers in groups) in the returned list of layers. If `includeChildLayers` is `true`, `getOperationLayers` and `getAllLayers` will return `AnyLayer[]` instead of `Layer[]`. By default `includeChildLayers` is `false` to avoid breaking changes.  
+The option `includeChildLayers` might be costly if the hierarchy of layers is deeply nested because the layer tree has to be traversed recursively.
+
+Example:
+```typescript
+const topLvlLayers : Layer[] = mapModel.map.layers.getAllLayers({
+    sortByDisplayOrder: true
+}); //return type is Layer[]
+const allLayers : AnyLayer[] = mapModel.map.layers.getAllLayers({
+    includeChildLayers: true,
+    sortByDisplayOrder: true
+}); //return type is AnyLayer[]
+
+const topLvlOpLayers : Layer[] = mapModel.map.layers.getOperationalLayers({
+    sortByDisplayOrder: true
+}); //return type is Layer[]
+const allOpLayers : AnyLayer[] = mapModel.map.layers.getOperationalLayers({
+    includeChildLayers: true,
+    sortByDisplayOrder: true
+}); //return type is AnyLayer[]
+```

--- a/src/packages/basemap-switcher/__snapshots__/BasemapSwitcher.test.tsx.snap
+++ b/src/packages/basemap-switcher/__snapshots__/BasemapSwitcher.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`should deactivate unavailable layers for selection 1`] = `
 <div
   class="basemap-switcher-select react-select--has-value css-79elbk"
-  data-theme="light"
 >
   <span
     class="css-1f43avz-a11yText-A11yText"
@@ -18,15 +17,12 @@ exports[`should deactivate unavailable layers for selection 1`] = `
   />
   <div
     class="react-select__control react-select__control--menu-is-open css-156sfem"
-    data-theme="light"
   >
     <div
       class="react-select__value-container react-select__value-container--has-value css-j93siq"
-      data-theme="light"
     >
       <div
         class="basemap-switcher-value react-select__single-value css-1xa1gs2"
-        data-theme="light"
       >
         <div
           class="css-u4p24i"
@@ -52,22 +48,18 @@ exports[`should deactivate unavailable layers for selection 1`] = `
     </div>
     <div
       class="react-select__indicators css-hfbj6y"
-      data-theme="light"
     >
       <hr
         aria-orientation="vertical"
         class="chakra-divider react-select__indicator-separator css-hxuk4g"
-        data-theme="light"
       />
       <div
         aria-hidden="true"
         class="react-select__indicator react-select__dropdown-indicator css-1hbdnuy"
-        data-theme="light"
       >
         <svg
           aria-hidden="true"
           class="chakra-icon css-onkibi"
-          data-theme="light"
           focusable="false"
           role="presentation"
           viewBox="0 0 24 24"
@@ -85,12 +77,10 @@ exports[`should deactivate unavailable layers for selection 1`] = `
   >
     <div
       class="react-select__menu css-ky7590"
-      data-theme="light"
     >
       <div
         aria-multiselectable="false"
         class="react-select__menu-list css-mkffje"
-        data-theme="light"
         id="react-select-11-listbox"
         role="listbox"
       >
@@ -98,7 +88,6 @@ exports[`should deactivate unavailable layers for selection 1`] = `
           aria-selected="true"
           class="basemap-switcher-option react-select__option react-select__option--is-focused react-select__option--is-selected css-2rk73n"
           data-focus="true"
-          data-theme="light"
           id="react-select-11-option-0"
           role="option"
           tabindex="-1"
@@ -113,7 +102,6 @@ exports[`should deactivate unavailable layers for selection 1`] = `
         <div
           aria-selected="false"
           class="basemap-switcher-option react-select__option css-p7801c"
-          data-theme="light"
           id="react-select-11-option-1"
           role="option"
           tabindex="-1"
@@ -134,7 +122,6 @@ exports[`should deactivate unavailable layers for selection 1`] = `
 exports[`should deactivate unavailable layers for selection 2`] = `
 <div
   class="basemap-switcher-select react-select--has-value css-79elbk"
-  data-theme="light"
 >
   <span
     class="css-1f43avz-a11yText-A11yText"
@@ -149,15 +136,12 @@ exports[`should deactivate unavailable layers for selection 2`] = `
   />
   <div
     class="react-select__control react-select__control--menu-is-open css-156sfem"
-    data-theme="light"
   >
     <div
       class="react-select__value-container react-select__value-container--has-value css-j93siq"
-      data-theme="light"
     >
       <div
         class="basemap-switcher-value react-select__single-value css-1xa1gs2"
-        data-theme="light"
       >
         <div
           class="css-u4p24i"
@@ -183,22 +167,18 @@ exports[`should deactivate unavailable layers for selection 2`] = `
     </div>
     <div
       class="react-select__indicators css-hfbj6y"
-      data-theme="light"
     >
       <hr
         aria-orientation="vertical"
         class="chakra-divider react-select__indicator-separator css-hxuk4g"
-        data-theme="light"
       />
       <div
         aria-hidden="true"
         class="react-select__indicator react-select__dropdown-indicator css-1hbdnuy"
-        data-theme="light"
       >
         <svg
           aria-hidden="true"
           class="chakra-icon css-onkibi"
-          data-theme="light"
           focusable="false"
           role="presentation"
           viewBox="0 0 24 24"
@@ -216,12 +196,10 @@ exports[`should deactivate unavailable layers for selection 2`] = `
   >
     <div
       class="react-select__menu css-ky7590"
-      data-theme="light"
     >
       <div
         aria-multiselectable="false"
         class="react-select__menu-list css-mkffje"
-        data-theme="light"
         id="react-select-11-listbox"
         role="listbox"
       >
@@ -229,7 +207,6 @@ exports[`should deactivate unavailable layers for selection 2`] = `
           aria-selected="true"
           class="basemap-switcher-option react-select__option react-select__option--is-focused react-select__option--is-selected css-2rk73n"
           data-focus="true"
-          data-theme="light"
           id="react-select-11-option-0"
           role="option"
           tabindex="-1"
@@ -244,7 +221,6 @@ exports[`should deactivate unavailable layers for selection 2`] = `
         <div
           aria-selected="false"
           class="basemap-switcher-option react-select__option css-p7801c"
-          data-theme="light"
           id="react-select-11-option-1"
           role="option"
           tabindex="-1"
@@ -270,7 +246,6 @@ exports[`should successfully create a basemap switcher component 1`] = `
 >
   <div
     class="basemap-switcher-select react-select--has-value css-79elbk"
-    data-theme="light"
   >
     <span
       class="css-1f43avz-a11yText-A11yText"
@@ -285,15 +260,12 @@ exports[`should successfully create a basemap switcher component 1`] = `
     />
     <div
       class="react-select__control react-select__control--menu-is-open css-156sfem"
-      data-theme="light"
     >
       <div
         class="react-select__value-container react-select__value-container--has-value css-j93siq"
-        data-theme="light"
       >
         <div
           class="basemap-switcher-value react-select__single-value css-1xa1gs2"
-          data-theme="light"
         >
           <div
             class="css-u4p24i"
@@ -319,22 +291,18 @@ exports[`should successfully create a basemap switcher component 1`] = `
       </div>
       <div
         class="react-select__indicators css-hfbj6y"
-        data-theme="light"
       >
         <hr
           aria-orientation="vertical"
           class="chakra-divider react-select__indicator-separator css-hxuk4g"
-          data-theme="light"
         />
         <div
           aria-hidden="true"
           class="react-select__indicator react-select__dropdown-indicator css-1hbdnuy"
-          data-theme="light"
         >
           <svg
             aria-hidden="true"
             class="chakra-icon css-onkibi"
-            data-theme="light"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -352,12 +320,10 @@ exports[`should successfully create a basemap switcher component 1`] = `
     >
       <div
         class="react-select__menu css-ky7590"
-        data-theme="light"
       >
         <div
           aria-multiselectable="false"
           class="react-select__menu-list css-mkffje"
-          data-theme="light"
           id="react-select-2-listbox"
           role="listbox"
         >
@@ -365,7 +331,6 @@ exports[`should successfully create a basemap switcher component 1`] = `
             aria-selected="true"
             class="basemap-switcher-option react-select__option react-select__option--is-focused react-select__option--is-selected css-2rk73n"
             data-focus="true"
-            data-theme="light"
             id="react-select-2-option-0"
             role="option"
             tabindex="-1"

--- a/src/packages/coordinate-search/__snapshots__/CoordinateInput.test.tsx.snap
+++ b/src/packages/coordinate-search/__snapshots__/CoordinateInput.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`should successfully create a coordinate input component 1`] = `
       >
         <div
           class="coordinate-input-select--has-value css-79elbk"
-          data-theme="light"
         >
           <span
             class="css-1f43avz-a11yText-A11yText"
@@ -50,15 +49,12 @@ exports[`should successfully create a coordinate input component 1`] = `
           />
           <div
             class="coordinate-input-select__control css-u1k0x6"
-            data-theme="light"
           >
             <div
               class="coordinate-input-select__value-container coordinate-input-select__value-container--has-value css-odo7kh"
-              data-theme="light"
             >
               <div
                 class="coordinate-input-select__single-value css-1xa1gs2"
-                data-theme="light"
               >
                 WGS 84
               </div>
@@ -78,22 +74,18 @@ exports[`should successfully create a coordinate input component 1`] = `
             </div>
             <div
               class="coordinate-input-select__indicators css-hfbj6y"
-              data-theme="light"
             >
               <hr
                 aria-orientation="vertical"
                 class="chakra-divider coordinate-input-select__indicator-separator css-ejwint"
-                data-theme="light"
               />
               <div
                 aria-hidden="true"
                 class="coordinate-input-select__indicator coordinate-input-select__dropdown-indicator css-4v68kg"
-                data-theme="light"
               >
                 <svg
                   aria-hidden="true"
                   class="chakra-icon css-onkibi"
-                  data-theme="light"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"

--- a/src/packages/coordinate-search/__snapshots__/CoordinateSearch.test.tsx.snap
+++ b/src/packages/coordinate-search/__snapshots__/CoordinateSearch.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`should successfully create a coordinate search component 1`] = `
       >
         <div
           class="coordinate-input-select--has-value css-79elbk"
-          data-theme="light"
         >
           <span
             class="css-1f43avz-a11yText-A11yText"
@@ -50,15 +49,12 @@ exports[`should successfully create a coordinate search component 1`] = `
           />
           <div
             class="coordinate-input-select__control css-u1k0x6"
-            data-theme="light"
           >
             <div
               class="coordinate-input-select__value-container coordinate-input-select__value-container--has-value css-odo7kh"
-              data-theme="light"
             >
               <div
                 class="coordinate-input-select__single-value css-1xa1gs2"
-                data-theme="light"
               >
                 WGS 84
               </div>
@@ -78,22 +74,18 @@ exports[`should successfully create a coordinate search component 1`] = `
             </div>
             <div
               class="coordinate-input-select__indicators css-hfbj6y"
-              data-theme="light"
             >
               <hr
                 aria-orientation="vertical"
                 class="chakra-divider coordinate-input-select__indicator-separator css-ejwint"
-                data-theme="light"
               />
               <div
                 aria-hidden="true"
                 class="coordinate-input-select__indicator coordinate-input-select__dropdown-indicator css-4v68kg"
-                data-theme="light"
               >
                 <svg
                   aria-hidden="true"
                   class="chakra-icon css-onkibi"
-                  data-theme="light"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -241,12 +241,17 @@ export interface LayerCollection {
     addLayer(layer: Layer): void;
 
     /**
-     * Returns all operational layers.
+     * Returns a list of operational layers on the top level.
+     * This does not include sublayers or layers in (nested) groups.
+     * Since this includes only top level layers the return type is a list of {@link Layer}
      */
     getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
 
     /**
-     * Returns all operational layers.
+     * Depending on `includeChildLayers`, this returns a list of all operational layers or all operational layers on the top level.
+     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers.
+     * Since this can also include {@link Sublayer} the return type is a list of {@link AnyLayer}.
+     * If the hierachy of child layers is deeply nested this operation can become costly if  `includeChildLayers` is `true`.
      */
     getOperationalLayers(
         options?: LayerRetrievalOptions & { includeChildLayers: boolean }
@@ -258,12 +263,17 @@ export interface LayerCollection {
     getLayerById(id: string): AnyLayer | undefined;
 
     /**
-     * Returns all layers known to this collection.
+     * Returns a list of top level layers known to this collection.
+     * This does not include sublayers or layers in (nested) groups.
+     * Since this includes only top level layers the return type is a list of {@link Layer}
      */
     getAllLayers(options?: LayerRetrievalOptions): Layer[];
 
     /**
-     * Returns all layers known to this collection.
+     * Depending on `includeChildLayers`, this returns a list of all layers or all top level layers known to this collection.
+     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers.
+     * Since this can also include {@link Sublayer} the return type is a list of {@link AnyLayer}.
+     * If the hierachy of child layers is deeply nested this operation can become costly if  `includeChildLayers` is `true`.
      */
     getAllLayers(options?: LayerRetrievalOptions & { includeChildLayers: boolean }): AnyLayer[];
 

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -247,11 +247,11 @@ export interface LayerCollection {
      * If parameter `includeChildLayers` is provided this returns list of {@link AnyLayer} since it can include {@link Sublayer}, otherwise a list of {@link Layer} is returned.
      * If the hierachy of child layers is deeply nested this operation can become costly if `includeChildLayers` is `true`.
      */
+
+    getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
     getOperationalLayers(
         options?: LayerRetrievalOptions & { includeChildLayers: boolean }
     ): AnyLayer[];
-    getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
-
     /**
      * Returns the layer identified by the `id` or undefined, if no such layer exists.
      */
@@ -264,8 +264,9 @@ export interface LayerCollection {
      * If parameter `includeChildLayers` is provided this returns list of {@link AnyLayer} since it can include {@link Sublayer}, otherwise a list of {@link Layer} is returned.
      * If the hierachy of child layers is deeply nested this operation can become costly if `includeChildLayers` is `true`.
      */
-    getAllLayers(options?: LayerRetrievalOptions & { includeChildLayers: boolean }): AnyLayer[];
     getAllLayers(options?: LayerRetrievalOptions): Layer[];
+    getAllLayers(options?: LayerRetrievalOptions & { includeChildLayers: boolean }): AnyLayer[];
+
 
     /**
      * Removes a layer identified by the `id` from the map.

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -241,21 +241,16 @@ export interface LayerCollection {
     addLayer(layer: Layer): void;
 
     /**
-     * Returns a list of operational layers on the top level.
-     * This does not include sublayers or layers in (nested) groups.
-     * Since this includes only top level layers the return type is a list of {@link Layer}
-     */
-    getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
-
-    /**
-     * Depending on `includeChildLayers`, this returns a list of all operational layers or all operational layers on the top level.
-     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers.
-     * Since this can also include {@link Sublayer} the return type is a list of {@link AnyLayer}.
-     * If the hierachy of child layers is deeply nested this operation can become costly if  `includeChildLayers` is `true`.
+     * Returns a list of operational layers.
+     * Depending on `includeChildLayers`, this returns a list of all operational layers or only operational layers on the top level.
+     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers, otherwise only top level layers are included.
+     * If parameter `includeChildLayers` is provided this returns list of {@link AnyLayer} since it can include {@link Sublayer}, otherwise a list of {@link Layer} is returned.
+     * If the hierachy of child layers is deeply nested this operation can become costly if `includeChildLayers` is `true`.
      */
     getOperationalLayers(
         options?: LayerRetrievalOptions & { includeChildLayers: boolean }
     ): AnyLayer[];
+    getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
 
     /**
      * Returns the layer identified by the `id` or undefined, if no such layer exists.
@@ -263,19 +258,14 @@ export interface LayerCollection {
     getLayerById(id: string): AnyLayer | undefined;
 
     /**
-     * Returns a list of top level layers known to this collection.
-     * This does not include sublayers or layers in (nested) groups.
-     * Since this includes only top level layers the return type is a list of {@link Layer}
-     */
-    getAllLayers(options?: LayerRetrievalOptions): Layer[];
-
-    /**
-     * Depending on `includeChildLayers`, this returns a list of all layers or all top level layers known to this collection.
-     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers.
-     * Since this can also include {@link Sublayer} the return type is a list of {@link AnyLayer}.
-     * If the hierachy of child layers is deeply nested this operation can become costly if  `includeChildLayers` is `true`.
+     * Returns a list of layers known to this collection. This includes base layers and operational layers.
+     * Depending on `includeChildLayers`, this returns a list of all layers or only top level layers.
+     * If `includeChildLayers` is `true` it returns a flat list that contains all parent layers and child layers, otherwise only top level layers are included.
+     * If parameter `includeChildLayers` is provided this returns list of {@link AnyLayer} since it can include {@link Sublayer}, otherwise a list of {@link Layer} is returned.
+     * If the hierachy of child layers is deeply nested this operation can become costly if `includeChildLayers` is `true`.
      */
     getAllLayers(options?: LayerRetrievalOptions & { includeChildLayers: boolean }): AnyLayer[];
+    getAllLayers(options?: LayerRetrievalOptions): Layer[];
 
     /**
      * Removes a layer identified by the `id` from the map.

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -246,6 +246,13 @@ export interface LayerCollection {
     getOperationalLayers(options?: LayerRetrievalOptions): Layer[];
 
     /**
+     * Returns all operational layers.
+     */
+    getOperationalLayers(
+        options?: LayerRetrievalOptions & { includeChildLayers: boolean }
+    ): AnyLayer[];
+
+    /**
      * Returns the layer identified by the `id` or undefined, if no such layer exists.
      */
     getLayerById(id: string): AnyLayer | undefined;
@@ -254,6 +261,11 @@ export interface LayerCollection {
      * Returns all layers known to this collection.
      */
     getAllLayers(options?: LayerRetrievalOptions): Layer[];
+
+    /**
+     * Returns all layers known to this collection.
+     */
+    getAllLayers(options?: LayerRetrievalOptions & { includeChildLayers: boolean }): AnyLayer[];
 
     /**
      * Removes a layer identified by the `id` from the map.

--- a/src/packages/map/model/LayerCollectionImpl.test.ts
+++ b/src/packages/map/model/LayerCollectionImpl.test.ts
@@ -609,6 +609,76 @@ describe("base layers", () => {
     });
 });
 
+it("it should return all layers including children", async () => {
+    const olBase = new TileLayer({
+        source: new OSM()
+    });
+    const base = new SimpleLayerImpl({
+        id: "base",
+        title: "baselayer",
+        olLayer: olBase,
+        isBaseLayer: true
+    });
+
+    const olLayer = new TileLayer({
+        source: new OSM()
+    });
+    const child = new SimpleLayerImpl({
+        id: "member",
+        title: "group member",
+        olLayer: olLayer
+    });
+    const group = new GroupLayer({
+        id: "group",
+        title: "group test",
+        layers: [child]
+    });
+
+    model = await create("foo", {
+        layers: [base, group]
+    });
+
+    const allLayers = model.layers.getAllLayers({includeChildLayers: true});
+    expect(allLayers.length).toBe(3); //base & group & child
+    const topLevelLayers = model.layers.getAllLayers({includeChildLayers: false});
+    expect(topLevelLayers.length).toBe(2); //base & group
+});
+
+it("it should return all operational layers including children", async () => {
+    const olBase = new TileLayer({
+        source: new OSM()
+    });
+    const base = new SimpleLayerImpl({
+        id: "base",
+        title: "baselayer",
+        olLayer: olBase,
+        isBaseLayer: true
+    });
+
+    const olLayer = new TileLayer({
+        source: new OSM()
+    });
+    const child = new SimpleLayerImpl({
+        id: "member",
+        title: "group member",
+        olLayer: olLayer
+    });
+    const group = new GroupLayer({
+        id: "group",
+        title: "group test",
+        layers: [child]
+    });
+
+    model = await create("foo", {
+        layers: [base, group]
+    });
+
+    const allOperationalLayers = model.layers.getOperationalLayers({includeChildLayers: true});
+    expect(allOperationalLayers.length).toBe(2); //group & child
+    const topLevelOperationalLayers = model.layers.getOperationalLayers({includeChildLayers: false});
+    expect(topLevelOperationalLayers.length).toBe(1); //group
+});
+
 function getLayerProps(layer: Layer) {
     return {
         title: layer.title,

--- a/src/packages/map/model/LayerCollectionImpl.test.ts
+++ b/src/packages/map/model/LayerCollectionImpl.test.ts
@@ -638,9 +638,9 @@ it("it should return all layers including children", async () => {
         layers: [base, group]
     });
 
-    const allLayers = model.layers.getAllLayers({includeChildLayers: true});
+    const allLayers = model.layers.getAllLayers({ includeChildLayers: true });
     expect(allLayers.length).toBe(3); //base & group & child
-    const topLevelLayers = model.layers.getAllLayers({includeChildLayers: false});
+    const topLevelLayers = model.layers.getAllLayers({ includeChildLayers: false });
     expect(topLevelLayers.length).toBe(2); //base & group
 });
 
@@ -673,9 +673,11 @@ it("it should return all operational layers including children", async () => {
         layers: [base, group]
     });
 
-    const allOperationalLayers = model.layers.getOperationalLayers({includeChildLayers: true});
+    const allOperationalLayers = model.layers.getOperationalLayers({ includeChildLayers: true });
     expect(allOperationalLayers.length).toBe(2); //group & child
-    const topLevelOperationalLayers = model.layers.getOperationalLayers({includeChildLayers: false});
+    const topLevelOperationalLayers = model.layers.getOperationalLayers({
+        includeChildLayers: false
+    });
     expect(topLevelOperationalLayers.length).toBe(1); //group
 });
 

--- a/src/packages/map/model/LayerCollectionImpl.test.ts
+++ b/src/packages/map/model/LayerCollectionImpl.test.ts
@@ -681,6 +681,45 @@ it("it should return all operational layers including children", async () => {
     expect(topLevelOperationalLayers.length).toBe(1); //group
 });
 
+it("it should return all layers including children ordered by display order (asc)", async () => {
+    const olBase = new TileLayer({
+        source: new OSM()
+    });
+    const base = new SimpleLayerImpl({
+        id: "base",
+        title: "baselayer",
+        olLayer: olBase,
+        isBaseLayer: true
+    });
+
+    const olLayer = new TileLayer({
+        source: new OSM()
+    });
+    const child = new SimpleLayerImpl({
+        id: "member",
+        title: "group member",
+        olLayer: olLayer
+    });
+    const group = new GroupLayer({
+        id: "group",
+        title: "group test",
+        layers: [child]
+    });
+
+    model = await create("foo", {
+        layers: [base, group]
+    });
+
+    const allLayers = model.layers.getAllLayers({
+        includeChildLayers: true,
+        sortByDisplayOrder: true
+    });
+    expect(allLayers.length).toBe(3);
+    expect(allLayers[0]).toBe(base);
+    expect(allLayers[1]).toBe(child);
+    expect(allLayers[2]).toBe(group);
+});
+
 function getLayerProps(layer: Layer) {
     return {
         title: layer.title,

--- a/src/packages/map/model/LayerCollectionImpl.ts
+++ b/src/packages/map/model/LayerCollectionImpl.ts
@@ -350,7 +350,6 @@ function getZIndexForAnyLayer(layer: AnyLayer): number {
         }
     }
 
-    
     //if layer has no zIndex, find nearest parent with zIndex
     let parent = layer.parent;
     while (parent) {
@@ -364,7 +363,7 @@ function getZIndexForAnyLayer(layer: AnyLayer): number {
                 return parentLayerZIndex;
             }
             parent = parent.parent;
-        }else{
+        } else {
             parent = parent.parentLayer; //no need to traverse nested sublayers -> directly jump to parent layer of sublayer
         }
     }

--- a/src/packages/scale-setter/__snapshots__/ScaleSetter.test.tsx.snap
+++ b/src/packages/scale-setter/__snapshots__/ScaleSetter.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`should successfully create a scale Setter component 1`] = `
       <svg
         aria-hidden="true"
         class="chakra-icon css-onkibi"
-        data-theme="light"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -74,7 +73,6 @@ exports[`should successfully create a scale setter component with additional css
       <svg
         aria-hidden="true"
         class="chakra-icon css-onkibi"
-        data-theme="light"
         focusable="false"
         viewBox="0 0 24 24"
       >

--- a/src/packages/search/__snapshots__/Search.test.tsx.snap
+++ b/src/packages/search/__snapshots__/Search.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`should successfully create a search component 1`] = `
 >
   <div
     class="search-component css-79elbk"
-    data-theme="light"
   >
     <span
       class="css-1f43avz-a11yText-A11yText"
@@ -23,15 +22,12 @@ exports[`should successfully create a search component 1`] = `
     />
     <div
       class="react-select__control css-i2418r"
-      data-theme="light"
     >
       <div
         class="search-value-container react-select__value-container css-j93siq"
-        data-theme="light"
       >
         <svg
           class="chakra-icon css-onkibi"
-          data-theme="light"
           focusable="false"
           style="position: absolute; left: 8px;"
           viewBox="0 0 24 24"
@@ -43,14 +39,12 @@ exports[`should successfully create a search component 1`] = `
         </svg>
         <div
           class="react-select__placeholder css-hji3d9"
-          data-theme="light"
           id="react-select-2-placeholder"
         >
           searchPlaceholder
         </div>
         <div
           class="react-select__input-container css-18euh9p"
-          data-theme="light"
           data-value=""
         >
           <input
@@ -63,7 +57,6 @@ exports[`should successfully create a search component 1`] = `
             autocomplete="off"
             autocorrect="off"
             class="react-select__input css-10wwmqn"
-            data-theme="light"
             id="react-select-2-input"
             role="combobox"
             spellcheck="false"
@@ -75,22 +68,18 @@ exports[`should successfully create a search component 1`] = `
       </div>
       <div
         class="react-select__indicators css-hfbj6y"
-        data-theme="light"
       >
         <hr
           aria-orientation="vertical"
           class="chakra-divider react-select__indicator-separator css-1xamfek"
-          data-theme="light"
         />
         <div
           aria-hidden="true"
           class="react-select__indicator react-select__dropdown-indicator css-am4s01"
-          data-theme="light"
         >
           <svg
             aria-hidden="true"
             class="chakra-icon css-onkibi"
-            data-theme="light"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"

--- a/src/packages/selection/__snapshots__/Selection.test.tsx.snap
+++ b/src/packages/selection/__snapshots__/Selection.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`should successfully create a selection component and select the first s
     </label>
     <div
       class="selection-source react-select react-select--has-value css-79elbk"
-      data-theme="light"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -36,15 +35,12 @@ exports[`should successfully create a selection component and select the first s
       />
       <div
         class="react-select__control css-156sfem"
-        data-theme="light"
       >
         <div
           class="react-select__value-container react-select__value-container--has-value css-j93siq"
-          data-theme="light"
         >
           <div
             class="selection-source-value selection-source-value--disabled react-select__single-value react-select__single-value--is-disabled css-1xa1gs2"
-            data-theme="light"
           >
             <div
               class="css-1x05v4l"
@@ -99,9 +95,8 @@ exports[`should successfully create a selection component and select the first s
             aria-expanded="false"
             aria-haspopup="true"
             aria-readonly="true"
-            aria-required="false"
             class="css-mohuvp-dummyInput-DummyInput"
-            id="field-:r0:"
+            id="react-select-2-input"
             inputmode="none"
             role="combobox"
             tabindex="0"
@@ -110,22 +105,18 @@ exports[`should successfully create a selection component and select the first s
         </div>
         <div
           class="react-select__indicators css-hfbj6y"
-          data-theme="light"
         >
           <hr
             aria-orientation="vertical"
             class="chakra-divider react-select__indicator-separator css-hxuk4g"
-            data-theme="light"
           />
           <div
             aria-hidden="true"
             class="react-select__indicator react-select__dropdown-indicator css-1hbdnuy"
-            data-theme="light"
           >
             <svg
               aria-hidden="true"
               class="chakra-icon css-onkibi"
-              data-theme="light"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"

--- a/src/packages/toc/__snapshots__/Toc.test.tsx.snap
+++ b/src/packages/toc/__snapshots__/Toc.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`should successfully create a toc component 1`] = `
     >
       <div
         class="basemap-switcher-select react-select--has-value css-79elbk"
-        data-theme="light"
       >
         <span
           class="css-1f43avz-a11yText-A11yText"
@@ -38,15 +37,12 @@ exports[`should successfully create a toc component 1`] = `
         />
         <div
           class="react-select__control react-select__control--menu-is-open css-156sfem"
-          data-theme="light"
         >
           <div
             class="react-select__value-container react-select__value-container--has-value css-j93siq"
-            data-theme="light"
           >
             <div
               class="basemap-switcher-value react-select__single-value css-1xa1gs2"
-              data-theme="light"
             >
               <div
                 class="css-u4p24i"
@@ -73,22 +69,18 @@ exports[`should successfully create a toc component 1`] = `
           </div>
           <div
             class="react-select__indicators css-hfbj6y"
-            data-theme="light"
           >
             <hr
               aria-orientation="vertical"
               class="chakra-divider react-select__indicator-separator css-hxuk4g"
-              data-theme="light"
             />
             <div
               aria-hidden="true"
               class="react-select__indicator react-select__dropdown-indicator css-1hbdnuy"
-              data-theme="light"
             >
               <svg
                 aria-hidden="true"
                 class="chakra-icon css-onkibi"
-                data-theme="light"
                 focusable="false"
                 role="presentation"
                 viewBox="0 0 24 24"
@@ -106,12 +98,10 @@ exports[`should successfully create a toc component 1`] = `
         >
           <div
             class="react-select__menu css-ky7590"
-            data-theme="light"
           >
             <div
               aria-multiselectable="false"
               class="react-select__menu-list css-mkffje"
-              data-theme="light"
               id="react-select-2-listbox"
               role="listbox"
             >
@@ -119,7 +109,6 @@ exports[`should successfully create a toc component 1`] = `
                 aria-selected="true"
                 class="basemap-switcher-option react-select__option react-select__option--is-focused react-select__option--is-selected css-2rk73n"
                 data-focus="true"
-                data-theme="light"
                 id="react-select-2-option-0"
                 role="option"
                 tabindex="-1"


### PR DESCRIPTION
- option `includeChildLayers` for `getOperationLayers` and `getAllLayers` to optionally include (nested) children (sublayers and layers in groups) in the returned list of layers
  - if `includeChildLayers` is `true`, `getOperationLayers` and `getAllLayers` will return `AnyLayer[]` instead of `Layer[]`. 
  - by default `includeChildLayers` is `false` to avoid breaking changes. 