### PR TITLE
Windowing System

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1781,6 +1781,60 @@ importers:
         specifier: 'catalog:'
         version: 5.3.0(react@18.3.1)
 
+  src/samples/window-sample/window-app:
+    dependencies:
+      '@open-pioneer/chakra-integration':
+        specifier: 'catalog:'
+        version: 2.4.0(@emotion/is-prop-valid@1.3.0)(@types/react@18.3.11)
+      '@open-pioneer/coordinate-viewer':
+        specifier: workspace:^
+        version: link:../../../packages/coordinate-viewer
+      '@open-pioneer/legend':
+        specifier: workspace:^
+        version: link:../../../packages/legend
+      '@open-pioneer/map':
+        specifier: workspace:^
+        version: link:../../../packages/map
+      '@open-pioneer/map-ui-components':
+        specifier: workspace:^
+        version: link:../../../packages/map-ui-components
+      '@open-pioneer/measurement':
+        specifier: workspace:^
+        version: link:../../../packages/measurement
+      '@open-pioneer/notifier':
+        specifier: 'catalog:'
+        version: 2.4.0(@chakra-ui/react@2.10.4(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(framer-motion@11.3.31(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@emotion/is-prop-valid@1.3.0)(@types/react@18.3.11)(typescript@5.6.3)
+      '@open-pioneer/printing':
+        specifier: workspace:^
+        version: link:../../../packages/printing
+      '@open-pioneer/react-utils':
+        specifier: 'catalog:'
+        version: 2.4.0(@emotion/is-prop-valid@1.3.0)(@types/react@18.3.11)
+      '@open-pioneer/scale-bar':
+        specifier: workspace:^
+        version: link:../../../packages/scale-bar
+      '@open-pioneer/scale-viewer':
+        specifier: workspace:^
+        version: link:../../../packages/scale-viewer
+      '@open-pioneer/spatial-bookmarks':
+        specifier: workspace:^
+        version: link:../../../packages/spatial-bookmarks
+      '@open-pioneer/toc':
+        specifier: workspace:^
+        version: link:../../../packages/toc
+      ol:
+        specifier: 'catalog:'
+        version: 10.3.1
+      react:
+        specifier: 'catalog:'
+        version: 18.3.1
+      react-icons:
+        specifier: 'catalog:'
+        version: 5.3.0(react@18.3.1)
+      window:
+        specifier: workspace:^
+        version: link:../../../experimental-packages/window
+
   src/testing/test-utils: {}
 
   support/disabled-package: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ catalogs:
       version: 11.13.0
     '@maplibre/maplibre-gl-style-spec':
       specifier: ^22.0.0
-      version: 22.0.0
+      version: 22.0.1
     '@open-pioneer/base-theme':
       specifier: ^2.4.0
       version: 2.4.0
@@ -192,6 +192,9 @@ catalogs:
     react-icons:
       specifier: ^5.3.0
       version: 5.3.0
+    react-rnd:
+      specifier: ^10.4.13
+      version: 10.4.14
     react-use:
       specifier: ^17.5.1
       version: 17.5.1
@@ -258,7 +261,7 @@ importers:
         version: 2.27.9
       '@maplibre/maplibre-gl-style-spec':
         specifier: 'catalog:'
-        version: 22.0.0
+        version: 22.0.1
       '@open-pioneer/build-package-cli':
         specifier: 'catalog:'
         version: 2.1.1(sass@1.80.3)(typescript@5.6.3)
@@ -411,6 +414,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
     publishDirectory: dist
+
+  src/experimental-packages/window:
+    dependencies:
+      '@open-pioneer/chakra-integration':
+        specifier: 'catalog:'
+        version: 2.4.0(@emotion/is-prop-valid@1.3.0)(@types/react@18.3.11)
+      react-rnd:
+        specifier: 'catalog:'
+        version: 10.4.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   src/packages/basemap-switcher:
     dependencies:
@@ -2522,10 +2534,6 @@ packages:
   '@mapbox/unitbezier@0.0.1':
     resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
 
-  '@maplibre/maplibre-gl-style-spec@22.0.0':
-    resolution: {integrity: sha512-kD8TxV6CdgHIEeam4xODVJNAT3hcvRhRl5RcNiu+FPR/JoMsExAQTruBGtv+jLppj4xt9V56pG/SHK8z6fv6xA==}
-    hasBin: true
-
   '@maplibre/maplibre-gl-style-spec@22.0.1':
     resolution: {integrity: sha512-V7bSw7Ui6+NhpeeuYqGoqamvKuy+3+uCvQ/t4ZJkwN8cx527CAlQQQ2kp+w5R9q+Tw6bUAH+fsq+mPEkicgT8g==}
     hasBin: true
@@ -3524,6 +3532,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -5047,6 +5059,12 @@ packages:
   rbush@4.0.1:
     resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
 
+  re-resizable@6.10.3:
+    resolution: {integrity: sha512-zvWb7X3RJMA4cuSrqoxgs3KR+D+pEXnGrD2FAD6BMYAULnZsSF4b7AOVyG6pC3VVNVOtlagGDCDmZSwWLjjBBw==}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-clientside-effect@1.2.6:
     resolution: {integrity: sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==}
     peerDependencies:
@@ -5056,6 +5074,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-draggable@4.4.6:
+    resolution: {integrity: sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==}
+    peerDependencies:
+      react: '>= 16.3.0'
+      react-dom: '>= 16.3.0'
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -5099,6 +5123,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-rnd@10.4.14:
+    resolution: {integrity: sha512-NLGc3IymymumPfHy3DXiHNIMOiTlj6xBNb2boHqrtwCgYDasNarpg8tdUY36JlJbrs0E4BvjYBkfEGqUPBsukg==}
+    peerDependencies:
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
 
   react-select@5.8.0:
     resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
@@ -5606,6 +5636,9 @@ packages:
 
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -6687,16 +6720,6 @@ snapshots:
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
   '@mapbox/unitbezier@0.0.1': {}
-
-  '@maplibre/maplibre-gl-style-spec@22.0.0':
-    dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/unitbezier': 0.0.1
-      json-stringify-pretty-compact: 4.0.0
-      minimist: 1.2.8
-      quickselect: 3.0.0
-      rw: 1.3.3
-      tinyqueue: 3.0.0
 
   '@maplibre/maplibre-gl-style-spec@22.0.1':
     dependencies:
@@ -7860,6 +7883,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  clsx@1.2.1: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -9597,6 +9622,11 @@ snapshots:
     dependencies:
       quickselect: 3.0.0
 
+  re-resizable@6.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react-clientside-effect@1.2.6(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
@@ -9607,6 +9637,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-draggable@4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 1.2.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-fast-compare@3.2.2: {}
 
@@ -9648,6 +9685,14 @@ snapshots:
       use-sidecar: 1.1.2(@types/react@18.3.11)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.11
+
+  react-rnd@10.4.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      re-resizable: 6.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-draggable: 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tslib: 2.6.2
 
   react-select@5.8.0(patch_hash=dmr4eel47u7r4xswxh72mgmyuq)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10210,6 +10255,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.4.0: {}
+
+  tslib@2.6.2: {}
 
   tslib@2.7.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ catalog:
   proj4: ^2.12.1
   react-dom: *react_version
   react-icons: ^5.3.0
+  react-rnd: ^10.4.13
   react-select: ^5.8.0
   react-use: ^17.5.1
   react: *react_version

--- a/src/experimental-packages/window/build.config.mjs
+++ b/src/experimental-packages/window/build.config.mjs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { defineBuildConfig } from "@open-pioneer/build-support";
+
+export default defineBuildConfig({
+    i18n: ["en", "de"]
+});

--- a/src/experimental-packages/window/i18n/de.yaml
+++ b/src/experimental-packages/window/i18n/de.yaml
@@ -1,0 +1,3 @@
+messages:
+  ariaLabel:
+    close: "Fenster schließen"

--- a/src/experimental-packages/window/i18n/en.yaml
+++ b/src/experimental-packages/window/i18n/en.yaml
@@ -1,0 +1,3 @@
+messages:
+  ariaLabel:
+    close: "Close window"

--- a/src/experimental-packages/window/index.ts
+++ b/src/experimental-packages/window/index.ts
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+export { Window, type WindowProps } from "./tsx/Window";

--- a/src/experimental-packages/window/package.json
+++ b/src/experimental-packages/window/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "window",
+    "version": "0.1.0",
+    "main": "index.ts",
+    "private": true,
+    "dependencies": {
+        "@open-pioneer/chakra-integration": "catalog:",
+        "react-rnd": "catalog:"
+    }
+}

--- a/src/experimental-packages/window/tsx/Window.tsx
+++ b/src/experimental-packages/window/tsx/Window.tsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Flex } from "@open-pioneer/chakra-integration";
+import { Rnd } from "react-rnd";
+import { useMemo, type ReactElement, type ReactNode } from "react";
+
+import { TitleBar, DRAG_HANDLE_CLASS_NAME } from "./titlebar/TitleBar";
+import { useFrame } from "./frame/useFrame";
+import type { WindowFrame } from "./frame/frame";
+import { useZIndex } from "./zindex/useZIndex";
+
+export function Window({
+    title, identifier, minWidth, minHeight, maxWidth, maxHeight, dragAnywhere = false,
+    children, onClose, ...windowFrame
+}: WindowProps): ReactElement {
+    const { initialFrame, onResizeStop, onDragStop } = useFrame(identifier, windowFrame);
+    const [zIndex, bringToFront] = useZIndex();
+    const style = useMemo(() => ({ zIndex }), [zIndex]);
+
+    return (
+        <Rnd
+            bounds="window"
+            default={initialFrame}
+            minWidth={minWidth ?? 250}
+            minHeight={minHeight ?? 250}
+            maxWidth={maxWidth}
+            maxHeight={maxHeight}
+            style={style}
+            dragHandleClassName={!dragAnywhere ? DRAG_HANDLE_CLASS_NAME : undefined}
+            onMouseDown={bringToFront}
+            onResizeStart={bringToFront}
+            onDragStart={bringToFront}
+            onResizeStop={onResizeStop}
+            onDragStop={onDragStop}
+        >
+            <Flex
+                direction="column"
+                width="full"
+                height="full"
+                bg="white"
+                overflow="hidden"
+                border="1px"
+                borderColor="gray.300"
+                borderRadius="md"
+                boxShadow="md"
+                zIndex={1}
+            >
+                <TitleBar title={title} onClose={onClose} />
+                <Box flex="1" padding="15px" overflow="auto">
+                    {children}
+                </Box>
+            </Flex>
+        </Rnd>
+    );
+}
+
+export type WindowProps = AdditionalWindowProps & WindowFrame;
+
+export interface AdditionalWindowProps {
+    readonly title?: string;
+    readonly identifier?: string;
+
+    readonly minWidth?: number;
+    readonly minHeight?: number;
+    readonly maxWidth?: number;
+    readonly maxHeight?: number;
+
+    readonly dragAnywhere?: boolean;
+    readonly children?: ReactNode | ReactNode[];
+
+    readonly onClose?: () => void;
+}
+
+export type { WindowFrame };

--- a/src/experimental-packages/window/tsx/Window.tsx
+++ b/src/experimental-packages/window/tsx/Window.tsx
@@ -10,9 +10,19 @@ import type { WindowFrame } from "./frame/frame";
 import { useZIndex } from "./zindex/useZIndex";
 
 export function Window({
-    title, identifier, minWidth, minHeight, maxWidth, maxHeight,
-    resizable = true, closable = true, draggable = true, dragAnywhere = false,
-    children, onClose, ...windowFrame
+    title,
+    identifier,
+    minWidth,
+    minHeight,
+    maxWidth,
+    maxHeight,
+    resizable = true,
+    closable = true,
+    draggable = true,
+    dragAnywhere = false,
+    children,
+    onClose,
+    ...windowFrame
 }: WindowProps): ReactElement {
     const { initialFrame, onResizeStop, onDragStop } = useFrame(identifier, windowFrame);
     const [zIndex, bringToFront] = useZIndex();

--- a/src/experimental-packages/window/tsx/Window.tsx
+++ b/src/experimental-packages/window/tsx/Window.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Flex } from "@open-pioneer/chakra-integration";
-import { Rnd } from "react-rnd";
+import { Rnd, type ResizeEnable } from "react-rnd";
 import { useMemo, type ReactElement, type ReactNode } from "react";
 
 import { TitleBar, DRAG_HANDLE_CLASS_NAME } from "./titlebar/TitleBar";
@@ -10,7 +10,8 @@ import type { WindowFrame } from "./frame/frame";
 import { useZIndex } from "./zindex/useZIndex";
 
 export function Window({
-    title, identifier, minWidth, minHeight, maxWidth, maxHeight, dragAnywhere = false,
+    title, identifier, minWidth, minHeight, maxWidth, maxHeight,
+    resizable = true, closable = true, draggable = true, dragAnywhere = false,
     children, onClose, ...windowFrame
 }: WindowProps): ReactElement {
     const { initialFrame, onResizeStop, onDragStop } = useFrame(identifier, windowFrame);
@@ -27,6 +28,8 @@ export function Window({
             maxHeight={maxHeight}
             style={style}
             dragHandleClassName={!dragAnywhere ? DRAG_HANDLE_CLASS_NAME : undefined}
+            enableResizing={resizable}
+            disableDragging={!draggable}
             onMouseDown={bringToFront}
             onResizeStart={bringToFront}
             onDragStart={bringToFront}
@@ -45,7 +48,7 @@ export function Window({
                 boxShadow="md"
                 zIndex={1}
             >
-                <TitleBar title={title} onClose={onClose} />
+                <TitleBar title={title} closeable={closable} onClose={onClose} />
                 <Box flex="1" padding="15px" overflow="auto">
                     {children}
                 </Box>
@@ -65,9 +68,12 @@ export interface AdditionalWindowProps {
     readonly maxWidth?: number;
     readonly maxHeight?: number;
 
+    readonly resizable?: ResizeEnable;
+    readonly closable?: boolean;
+    readonly draggable?: boolean;
     readonly dragAnywhere?: boolean;
-    readonly children?: ReactNode | ReactNode[];
 
+    readonly children?: ReactNode | ReactNode[];
     readonly onClose?: () => void;
 }
 

--- a/src/experimental-packages/window/tsx/frame/frame.ts
+++ b/src/experimental-packages/window/tsx/frame/frame.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import type { Props as RndProps } from "react-rnd";
+
+export function toRndFrame(windowFrame: WindowFrame): RndFrame {
+    return {
+        x: Math.max(
+            0, windowFrame.left ?? window.innerWidth - windowFrame.right - windowFrame.width
+        ),
+        y: Math.max(
+            0, windowFrame.top ?? window.innerHeight - windowFrame.bottom - windowFrame.height
+        ),
+        width: windowFrame.width ?? window.innerWidth - windowFrame.left - windowFrame.right,
+        height: windowFrame.height ?? window.innerHeight - windowFrame.top - windowFrame.bottom
+    };
+}
+
+export function isRndFrame(value: unknown): value is RndFrame {
+    return isObject(value) && RND_FRAME_KEYS.every((key) => typeof value[key] === "number");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+// Make sure the window frame does not exceed the web page boundaries.
+export function normalize(frame: RndFrame): RndFrame {
+    const width = Math.min(frame.width, window.innerWidth);
+    const height = Math.min(frame.height, window.innerHeight);
+
+    return {
+        x: frame.x - Math.max(0, frame.x + width - window.innerWidth),
+        y: frame.y - Math.max(0, frame.y + height - window.innerHeight),
+        width,
+        height
+    };
+}
+
+const RND_FRAME_KEYS: (keyof RndFrame)[] = ["x", "y", "width", "height"];
+
+export type WindowFrame = Horizontal & Vertical;
+
+type Horizontal = Xor<Value<"left" | "width">, Value<"right" | "width">, Value<"left" | "right">>;
+type Vertical = Xor<Value<"top" | "height">, Value<"bottom" | "height">, Value<"top" | "bottom">>;
+
+type Value<K extends string> = {
+    readonly [L in K]: number
+};
+
+type Xor<T, U, V> = (T & Without<T, U | V>) | (U & Without<U, T | V>) | (V & Without<V, T | U>);
+
+type Without<T, U> = {
+    readonly [K in Exclude<keyof U, keyof T>]?: never;
+};
+
+export type RndFrame = NonNullableReadonlyNumeric<RndProps["default"]>;
+
+type NonNullableReadonlyNumeric<T> = {
+    readonly [K in keyof NonNullable<T>]: number;
+};

--- a/src/experimental-packages/window/tsx/frame/frame.ts
+++ b/src/experimental-packages/window/tsx/frame/frame.ts
@@ -5,10 +5,12 @@ import type { Props as RndProps } from "react-rnd";
 export function toRndFrame(windowFrame: WindowFrame): RndFrame {
     return {
         x: Math.max(
-            0, windowFrame.left ?? window.innerWidth - windowFrame.right - windowFrame.width
+            0,
+            windowFrame.left ?? window.innerWidth - windowFrame.right - windowFrame.width
         ),
         y: Math.max(
-            0, windowFrame.top ?? window.innerHeight - windowFrame.bottom - windowFrame.height
+            0,
+            windowFrame.top ?? window.innerHeight - windowFrame.bottom - windowFrame.height
         ),
         width: windowFrame.width ?? window.innerWidth - windowFrame.left - windowFrame.right,
         height: windowFrame.height ?? window.innerHeight - windowFrame.top - windowFrame.bottom
@@ -44,7 +46,7 @@ type Horizontal = Xor<Value<"left" | "width">, Value<"right" | "width">, Value<"
 type Vertical = Xor<Value<"top" | "height">, Value<"bottom" | "height">, Value<"top" | "bottom">>;
 
 type Value<K extends string> = {
-    readonly [L in K]: number
+    readonly [L in K]: number;
 };
 
 type Xor<T, U, V> = (T & Without<T, U | V>) | (U & Without<U, T | V>) | (V & Without<V, T | U>);

--- a/src/experimental-packages/window/tsx/frame/useFrame.ts
+++ b/src/experimental-packages/window/tsx/frame/useFrame.ts
@@ -6,10 +6,7 @@ import { toRndFrame, type RndFrame, type WindowFrame } from "./frame";
 import { useFrameSavers, type FrameSavers } from "./useFrameSavers";
 import { useLocalStorageFrame } from "./useLocalStorageFrame";
 
-export function useFrame(
-    identifier: string | undefined,
-    windowFrame: WindowFrame
-): FrameObject {
+export function useFrame(identifier: string | undefined, windowFrame: WindowFrame): FrameObject {
     const [localStorageFrame, setLocalStorageFrame] = useLocalStorageFrame(identifier);
 
     const initialFrame = useMemo(() => {

--- a/src/experimental-packages/window/tsx/frame/useFrame.ts
+++ b/src/experimental-packages/window/tsx/frame/useFrame.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo } from "react";
+
+import { toRndFrame, type RndFrame, type WindowFrame } from "./frame";
+import { useFrameSavers, type FrameSavers } from "./useFrameSavers";
+import { useLocalStorageFrame } from "./useLocalStorageFrame";
+
+export function useFrame(
+    identifier: string | undefined,
+    windowFrame: WindowFrame
+): FrameObject {
+    const [localStorageFrame, setLocalStorageFrame] = useLocalStorageFrame(identifier);
+
+    const initialFrame = useMemo(() => {
+        return localStorageFrame ?? toRndFrame(windowFrame);
+    }, [localStorageFrame, windowFrame]);
+
+    const frameSavers = useFrameSavers(initialFrame, setLocalStorageFrame);
+
+    return useMemo(() => ({ initialFrame, ...frameSavers }), [initialFrame, frameSavers]);
+}
+
+interface FrameObject extends FrameSavers {
+    readonly initialFrame: RndFrame;
+}

--- a/src/experimental-packages/window/tsx/frame/useFrameSavers.ts
+++ b/src/experimental-packages/window/tsx/frame/useFrameSavers.ts
@@ -10,20 +10,23 @@ export function useFrameSavers(
 ): FrameSavers {
     const size = useRef({ width, height });
 
-    return useMemo(() => ({
-        onResizeStop(_, __, { style }, ___, { x, y }) {
-            const newSize = {
-                width: parseInt(style.width),
-                height: parseInt(style.height)
-            };
-            setLocalStorageFrame({ x, y, ...newSize });
-            size.current = newSize;
-        },
+    return useMemo(
+        () => ({
+            onResizeStop(_, __, { style }, ___, { x, y }) {
+                const newSize = {
+                    width: parseInt(style.width),
+                    height: parseInt(style.height)
+                };
+                setLocalStorageFrame({ x, y, ...newSize });
+                size.current = newSize;
+            },
 
-        onDragStop(_, { x, y }) {
-            setLocalStorageFrame({ x, y, ...size.current });
-        }
-    }), [setLocalStorageFrame]);
+            onDragStop(_, { x, y }) {
+                setLocalStorageFrame({ x, y, ...size.current });
+            }
+        }),
+        [setLocalStorageFrame]
+    );
 }
 
 export type FrameSavers = Pick<RndProps, "onResizeStop" | "onDragStop">;

--- a/src/experimental-packages/window/tsx/frame/useFrameSavers.ts
+++ b/src/experimental-packages/window/tsx/frame/useFrameSavers.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo, useRef } from "react";
+import type { Props as RndProps } from "react-rnd";
+import type { RndFrame } from "./frame";
+
+export function useFrameSavers(
+    { width, height }: RndFrame,
+    setLocalStorageFrame: (frame: RndFrame) => void
+): FrameSavers {
+    const size = useRef({ width, height });
+
+    return useMemo(() => ({
+        onResizeStop(_, __, { style }, ___, { x, y }) {
+            const newSize = {
+                width: parseInt(style.width),
+                height: parseInt(style.height)
+            };
+            setLocalStorageFrame({ x, y, ...newSize });
+            size.current = newSize;
+        },
+
+        onDragStop(_, { x, y }) {
+            setLocalStorageFrame({ x, y, ...size.current });
+        }
+    }), [setLocalStorageFrame]);
+}
+
+export type FrameSavers = Pick<RndProps, "onResizeStop" | "onDragStop">;

--- a/src/experimental-packages/window/tsx/frame/useLocalStorageFrame.ts
+++ b/src/experimental-packages/window/tsx/frame/useLocalStorageFrame.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo } from "react";
+import { isRndFrame, normalize, type RndFrame } from "./frame";
+
+export function useLocalStorageFrame(identifier: string | undefined): LocalStorageFrameState {
+    return useMemo(() => [
+        getFrame(identifier),
+        (frame) => setFrame(identifier, frame)
+    ], [identifier]);
+}
+
+function getFrame(identifier: string | undefined): RndFrame | undefined {
+    try {
+        if (identifier != null) {
+            const key = getLocalStorageKey(identifier);
+            const item = localStorage.getItem(key);
+            if (item != null) {
+                const frame = JSON.parse(item);
+                if (isRndFrame(frame)) {
+                    return normalize(frame);
+                }
+            }
+        }
+        return undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function setFrame(identifier: string | undefined, frame: RndFrame): void {
+    try {
+        if (identifier != null) {
+            const key = getLocalStorageKey(identifier);
+            const item = JSON.stringify(frame);
+            localStorage.setItem(key, item);
+        }
+    } catch { /* ignore */ }
+}
+
+function getLocalStorageKey(identifier: string): string {
+    return `${LOCAL_STORAGE_KEY_PREFIX}-${identifier}`;
+}
+
+const LOCAL_STORAGE_KEY_PREFIX = "window-frame";
+
+type LocalStorageFrameState = [RndFrame | undefined, (frame: RndFrame) => void];

--- a/src/experimental-packages/window/tsx/frame/useLocalStorageFrame.ts
+++ b/src/experimental-packages/window/tsx/frame/useLocalStorageFrame.ts
@@ -4,10 +4,10 @@ import { useMemo } from "react";
 import { isRndFrame, normalize, type RndFrame } from "./frame";
 
 export function useLocalStorageFrame(identifier: string | undefined): LocalStorageFrameState {
-    return useMemo(() => [
-        getFrame(identifier),
-        (frame) => setFrame(identifier, frame)
-    ], [identifier]);
+    return useMemo(
+        () => [getFrame(identifier), (frame) => setFrame(identifier, frame)],
+        [identifier]
+    );
 }
 
 function getFrame(identifier: string | undefined): RndFrame | undefined {
@@ -35,7 +35,9 @@ function setFrame(identifier: string | undefined, frame: RndFrame): void {
             const item = JSON.stringify(frame);
             localStorage.setItem(key, item);
         }
-    } catch { /* ignore */ }
+    } catch {
+        /* ignore */
+    }
 }
 
 function getLocalStorageKey(identifier: string): string {

--- a/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
+++ b/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
@@ -5,7 +5,7 @@ import { useIntl } from "open-pioneer:react-hooks";
 import { MdClose } from "react-icons/md";
 import { useCallback, useMemo, type MouseEventHandler, type ReactElement } from "react";
 
-export function TitleBar({ title, onClose }: TitleBarProps): ReactElement {
+export function TitleBar({ title, closeable, onClose }: TitleBarProps): ReactElement {
     const { formatMessage } = useIntl();
     const ariaLabel = useMemo(() => formatMessage({ id: "ariaLabel.close" }), [formatMessage]);
 
@@ -25,17 +25,19 @@ export function TitleBar({ title, onClose }: TitleBarProps): ReactElement {
         >
             <Flex direction="row" justify="space-between" align="center">
                 <Text fontWeight="bold" fontSize="md">{title}</Text>
-                <IconButton
-                    icon={<MdClose />}
-                    size="sm"
-                    variant="ghost"
-                    color="white"
-                    aria-label={ariaLabel}
-                    style={STYLES.closeButton}
-                    _hover={STYLES.hoveredCloseButton}
-                    _active={STYLES.activeCloseButton}
-                    onClick={onClose}
-                />
+                {closeable && (
+                    <IconButton
+                        icon={<MdClose />}
+                        size="sm"
+                        variant="ghost"
+                        color="white"
+                        aria-label={ariaLabel}
+                        style={STYLES.closeButton}
+                        _hover={STYLES.hoveredCloseButton}
+                        _active={STYLES.activeCloseButton}
+                        onClick={onClose}
+                    />
+                )}
             </Flex>
         </Box>
     );
@@ -51,5 +53,6 @@ const STYLES = {
 
 interface TitleBarProps {
     readonly title: string | undefined;
+    readonly closeable: boolean;
     readonly onClose: (() => void) | undefined;
 }

--- a/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
+++ b/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
@@ -24,7 +24,9 @@ export function TitleBar({ title, closeable, onClose }: TitleBarProps): ReactEle
             onMouseDown={preventFocus}
         >
             <Flex direction="row" justify="space-between" align="center">
-                <Text fontWeight="bold" fontSize="md">{title}</Text>
+                <Text fontWeight="bold" fontSize="md">
+                    {title}
+                </Text>
                 {closeable && (
                     <IconButton
                         icon={<MdClose />}

--- a/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
+++ b/src/experimental-packages/window/tsx/titlebar/TitleBar.tsx
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Flex, IconButton, Text } from "@chakra-ui/react";
+import { useIntl } from "open-pioneer:react-hooks";
+import { MdClose } from "react-icons/md";
+import { useCallback, useMemo, type MouseEventHandler, type ReactElement } from "react";
+
+export function TitleBar({ title, onClose }: TitleBarProps): ReactElement {
+    const { formatMessage } = useIntl();
+    const ariaLabel = useMemo(() => formatMessage({ id: "ariaLabel.close" }), [formatMessage]);
+
+    const preventFocus = useCallback<MouseEventHandler>((event) => {
+        event.preventDefault();
+    }, []);
+
+    return (
+        <Box
+            className={DRAG_HANDLE_CLASS_NAME}
+            bg="trails.500"
+            color="white"
+            padding="8px 5px 8px 12px"
+            cursor="move"
+            userSelect="none"
+            onMouseDown={preventFocus}
+        >
+            <Flex direction="row" justify="space-between" align="center">
+                <Text fontWeight="bold" fontSize="md">{title}</Text>
+                <IconButton
+                    icon={<MdClose />}
+                    size="sm"
+                    variant="ghost"
+                    color="white"
+                    aria-label={ariaLabel}
+                    style={STYLES.closeButton}
+                    _hover={STYLES.hoveredCloseButton}
+                    _active={STYLES.activeCloseButton}
+                    onClick={onClose}
+                />
+            </Flex>
+        </Box>
+    );
+}
+
+export const DRAG_HANDLE_CLASS_NAME = "window-title-bar-drag-handle";
+
+const STYLES = {
+    closeButton: { background: "transparent" },
+    hoveredCloseButton: { color: "gray.300" },
+    activeCloseButton: { color: "gray.500" }
+};
+
+interface TitleBarProps {
+    readonly title: string | undefined;
+    readonly onClose: (() => void) | undefined;
+}

--- a/src/experimental-packages/window/tsx/zindex/useZIndex.ts
+++ b/src/experimental-packages/window/tsx/zindex/useZIndex.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export function useZIndex(): [number, () => void] {
+    const windowId = useMemo(() => getNewId(), []);
+    const [zIndex, setZIndex] = useState(0);
+
+    const bringToFront = useCallback(() => {
+        const newZIndex = findMaxZIndex(windowId) + 1;
+        zIndices.set(windowId, newZIndex);
+        setZIndex(newZIndex);
+    }, [windowId]);
+
+    useEffect(() => {
+        bringToFront();
+        return () => void zIndices.delete(windowId);
+    }, [bringToFront, windowId]);
+
+    return [zIndex, bringToFront];
+}
+
+function getNewId(): string {
+    return `window-${Math.random()}`;
+}
+
+function findMaxZIndex(windowId: string): number {
+    let maximum = 0;
+    for (const [id, zIndex] of zIndices.entries()) {
+        if (id !== windowId && zIndex > maximum) {
+            maximum = zIndex;
+        }
+    }
+    return maximum;
+}
+
+const zIndices = new Map<string, number>();

--- a/src/index.html
+++ b/src/index.html
@@ -101,6 +101,11 @@
                 <br />
                 Test app for a sidebar.
             </li>
+            <li>
+                <a href="./samples/window-sample/">Windows</a>
+                <br />
+                Test app for the <code>window</code> package.
+            </li>
         </ul>
     </body>
 </html>

--- a/src/samples/window-sample/index.html
+++ b/src/samples/window-sample/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" style="height: 100%">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Window Sample App</title>
+        <link rel="icon" type="image/x-icon" href="./../../favicon.ico" />
+        <style>
+            html,
+            body {
+                margin: 0px;
+            }
+            .full-height {
+                height: 100%;
+                max-height: 100%;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+
+    <body class="full-height">
+        <window-app class="full-height" />
+        <script type="module" src="./window-app/app.ts"></script>
+    </body>
+</html>

--- a/src/samples/window-sample/window-app/app.ts
+++ b/src/samples/window-sample/window-app/app.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { createCustomElement } from "@open-pioneer/runtime";
+import * as appMetadata from "open-pioneer:app";
+import { WindowApp } from "./tsx/WindowApp";
+
+const URL_PARAMS = new URLSearchParams(window.location.search);
+const FORCED_LANG = URL_PARAMS.get("lang") || undefined;
+
+const Element = createCustomElement({
+    component: WindowApp,
+    appMetadata,
+    config: {
+        locale: FORCED_LANG
+    }
+});
+
+customElements.define("window-app", Element);

--- a/src/samples/window-sample/window-app/build.config.mjs
+++ b/src/samples/window-sample/window-app/build.config.mjs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { defineBuildConfig } from "@open-pioneer/build-support";
+
+export default defineBuildConfig({
+    i18n: ["en", "de"],
+    services: {
+        MainMapProvider: {
+            provides: ["map.MapConfigProvider"]
+        }
+    }
+});

--- a/src/samples/window-sample/window-app/i18n/de.yaml
+++ b/src/samples/window-sample/window-app/i18n/de.yaml
@@ -1,0 +1,7 @@
+messages:
+  toolTitle:
+    bookmarks: "Lesezeichen"
+    legend: "Legende"
+    measurement: "Messen"
+    printing: "Drucken"
+    toc: "Karteninhalt"

--- a/src/samples/window-sample/window-app/i18n/en.yaml
+++ b/src/samples/window-sample/window-app/i18n/en.yaml
@@ -1,0 +1,7 @@
+messages:
+  toolTitle:
+    bookmarks: "Bookmarks"
+    legend: "Legend"
+    measurement: "Measurement"
+    printing: "Printing"
+    toc: "Table of Contents"

--- a/src/samples/window-sample/window-app/package.json
+++ b/src/samples/window-sample/window-app/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "window-app",
+    "private": true,
+    "dependencies": {
+        "@open-pioneer/chakra-integration": "catalog:",
+        "@open-pioneer/coordinate-viewer": "workspace:^",
+        "@open-pioneer/legend": "workspace:^",
+        "@open-pioneer/map": "workspace:^",
+        "@open-pioneer/map-ui-components": "workspace:^",
+        "@open-pioneer/measurement": "workspace:^",
+        "@open-pioneer/notifier": "catalog:",
+        "@open-pioneer/printing": "workspace:^",
+        "@open-pioneer/react-utils": "catalog:",
+        "@open-pioneer/scale-bar": "workspace:^",
+        "@open-pioneer/scale-viewer": "workspace:^",
+        "@open-pioneer/spatial-bookmarks": "workspace:^",
+        "@open-pioneer/toc": "workspace:^",
+        "ol": "catalog:",
+        "react": "catalog:",
+        "react-icons": "catalog:",
+        "window": "workspace:^"
+    },
+    "version": "0.0.1"
+}

--- a/src/samples/window-sample/window-app/services.ts
+++ b/src/samples/window-sample/window-app/services.ts
@@ -1,8 +1,3 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-export {
-    Window,
-    type AdditionalWindowProps,
-    type WindowFrame,
-    type WindowProps
-} from "./tsx/Window";
+export { MainMapProvider } from "./tsx/MainMapProvider";

--- a/src/samples/window-sample/window-app/tsx/MainMapProvider.ts
+++ b/src/samples/window-sample/window-app/tsx/MainMapProvider.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import {
-    SimpleLayer, WMSLayer, type Layer, type MapConfigProvider, type MapConfig
+    SimpleLayer,
+    WMSLayer,
+    type Layer,
+    type MapConfigProvider,
+    type MapConfig
 } from "@open-pioneer/map";
 
 import { Tile as TileLayer } from "ol/layer";
@@ -19,10 +23,7 @@ export class MainMapProvider implements MapConfigProvider {
                 zoom: 14
             },
             projection: "EPSG:3857",
-            layers: [
-                this.createOSMLayer(),
-                this.createStrassenLayer()
-            ]
+            layers: [this.createOSMLayer(), this.createStrassenLayer()]
         };
     }
 

--- a/src/samples/window-sample/window-app/tsx/MainMapProvider.ts
+++ b/src/samples/window-sample/window-app/tsx/MainMapProvider.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import {
+    SimpleLayer, WMSLayer, type Layer, type MapConfigProvider, type MapConfig
+} from "@open-pioneer/map";
+
+import { Tile as TileLayer } from "ol/layer";
+import { OSM } from "ol/source";
+
+export class MainMapProvider implements MapConfigProvider {
+    async getMapConfig(): Promise<MapConfig> {
+        return {
+            initialView: {
+                kind: "position",
+                center: {
+                    x: 847541,
+                    y: 6793584
+                },
+                zoom: 14
+            },
+            projection: "EPSG:3857",
+            layers: [
+                this.createOSMLayer(),
+                this.createStrassenLayer()
+            ]
+        };
+    }
+
+    get mapId(): string {
+        return MAP_ID;
+    }
+
+    private createOSMLayer(): Layer {
+        return new SimpleLayer({
+            title: "OpenStreetMap",
+            olLayer: new TileLayer({
+                source: new OSM(),
+                properties: {
+                    title: "OSM"
+                }
+            }),
+            isBaseLayer: true
+        });
+    }
+
+    private createStrassenLayer(): Layer {
+        return new WMSLayer({
+            title: "Straßennetz Landesbetrieb Straßenbau NRW",
+            url: "https://www.wms.nrw.de/wms/strassen_nrw_wms",
+            visible: true,
+            sublayers: [
+                {
+                    name: "1",
+                    title: "Verwaltungen",
+                    attributes: {
+                        "legend": {
+                            imageUrl: "https://www.wms.nrw.de/legends/wms/strassen_nrw_wms/1.png"
+                        }
+                    }
+                },
+                {
+                    name: "4",
+                    title: "Abschnitte und Äste"
+                },
+                {
+                    name: "6",
+                    title: "Unfälle"
+                }
+            ]
+        });
+    }
+}
+
+export const MAP_ID = "main";

--- a/src/samples/window-sample/window-app/tsx/MapTool.tsx
+++ b/src/samples/window-sample/window-app/tsx/MapTool.tsx
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { SpatialBookmarks } from "@open-pioneer/spatial-bookmarks";
+import { Legend } from "@open-pioneer/legend";
+import { Measurement } from "@open-pioneer/measurement";
+import { Printing } from "@open-pioneer/printing";
+import { Toc } from "@open-pioneer/toc";
+
+import { useIntl } from "open-pioneer:react-hooks";
+import type { ReactElement } from "react";
+
+import { ToolWindow, type ToolbarStateProps } from "./ToolWindow";
+
+export function MapTool(
+    { tool, toolbarStateKey, toolbarState, setToolbarState }: MapToolProps
+): ReactElement {
+    const { formatMessage } = useIntl();
+
+    switch (tool) {
+        case "bookmarks":
+            return (
+                <ToolWindow
+                    title={formatMessage({ id: "toolTitle.bookmarks" })}
+                    identifier="bookmarks"
+                    right={60}
+                    bottom={35}
+                    width={400}
+                    height={310}
+                    minWidth={350}
+                    minHeight={310}
+                    toolbarStateKey={toolbarStateKey}
+                    toolbarState={toolbarState}
+                    setToolbarState={setToolbarState}
+                >
+                    <SpatialBookmarks />
+                </ToolWindow>
+            );
+
+        case "legend":
+            return (
+                <ToolWindow
+                    title={formatMessage({ id: "toolTitle.legend" })}
+                    identifier="legend"
+                    left={10}
+                    bottom={35}
+                    width={450}
+                    height={350}
+                    minWidth={300}
+                    minHeight={300}
+                    toolbarStateKey={toolbarStateKey}
+                    toolbarState={toolbarState}
+                    setToolbarState={setToolbarState}
+                >
+                    <Legend />
+                </ToolWindow>
+            );
+
+        case "measurement":
+            return (
+                <ToolWindow
+                    title={formatMessage({ id: "toolTitle.measurement" })}
+                    identifier="measurement"
+                    top={10}
+                    right={10}
+                    width={300}
+                    height={250}
+                    resizable={false}
+                    toolbarStateKey={toolbarStateKey}
+                    toolbarState={toolbarState}
+                    setToolbarState={setToolbarState}
+                >
+                    <Measurement />
+                </ToolWindow>
+            );
+
+        case "printing":
+            return (
+                <ToolWindow
+                    title={formatMessage({ id: "toolTitle.printing" })}
+                    identifier="printing"
+                    right={10}
+                    top={270}
+                    width={350}
+                    height={250}
+                    minWidth={300}
+                    minHeight={250}
+                    maxWidth={400}
+                    maxHeight={400}
+                    toolbarStateKey={toolbarStateKey}
+                    toolbarState={toolbarState}
+                    setToolbarState={setToolbarState}
+                >
+                    <Printing />
+                </ToolWindow>
+            );
+
+        case "toc":
+            return (
+                <ToolWindow
+                    title={formatMessage({ id: "toolTitle.toc" })}
+                    identifier="toc"
+                    top={10}
+                    left={10}
+                    width={280}
+                    height={450}
+                    minWidth={250}
+                    minHeight={250}
+                    toolbarStateKey={toolbarStateKey}
+                    toolbarState={toolbarState}
+                    setToolbarState={setToolbarState}
+                >
+                    <Toc />
+                </ToolWindow>
+            );
+    }
+}
+
+interface MapToolProps extends ToolbarStateProps {
+    readonly tool: Tool;
+}
+
+type Tool = "bookmarks" | "legend" | "measurement" | "printing" | "toc";

--- a/src/samples/window-sample/window-app/tsx/MapTool.tsx
+++ b/src/samples/window-sample/window-app/tsx/MapTool.tsx
@@ -11,9 +11,12 @@ import type { ReactElement } from "react";
 
 import { ToolWindow, type ToolbarStateProps } from "./ToolWindow";
 
-export function MapTool(
-    { tool, toolbarStateKey, toolbarState, setToolbarState }: MapToolProps
-): ReactElement {
+export function MapTool({
+    tool,
+    toolbarStateKey,
+    toolbarState,
+    setToolbarState
+}: MapToolProps): ReactElement {
     const { formatMessage } = useIntl();
 
     switch (tool) {

--- a/src/samples/window-sample/window-app/tsx/ToolWindow.tsx
+++ b/src/samples/window-sample/window-app/tsx/ToolWindow.tsx
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import {
+    useCallback, type Dispatch, type ReactElement, type ReactNode, type SetStateAction
+} from "react";
+
+import { Window, type WindowProps } from "window";
+import type { ToolbarState } from "./Toolbar";
+
+export function ToolWindow(
+    { toolbarStateKey, toolbarState, setToolbarState, children, ...windowProps }: ToolWindowProps
+): ReactElement | undefined {
+    const isVisible = toolbarState[toolbarStateKey];
+
+    const onClose = useCallback(() => {
+        setToolbarState((toolbarState) => ({
+            ...toolbarState,
+            [toolbarStateKey]: false
+        }));
+    }, [setToolbarState, toolbarStateKey]);
+
+    if (isVisible) {
+        return (
+            <Window onClose={onClose} {...windowProps}>
+                {children}
+            </Window>
+        );
+    } else {
+        return undefined;
+    }
+}
+
+export interface ToolbarStateProps {
+    readonly toolbarStateKey: keyof ToolbarState;
+    readonly toolbarState: ToolbarState;
+    readonly setToolbarState: Dispatch<SetStateAction<ToolbarState>>;
+}
+
+interface Children {
+    readonly children?: ReactNode;
+}
+
+type ToolWindowProps = WindowProps & ToolbarStateProps & Children;

--- a/src/samples/window-sample/window-app/tsx/ToolWindow.tsx
+++ b/src/samples/window-sample/window-app/tsx/ToolWindow.tsx
@@ -1,15 +1,23 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import {
-    useCallback, type Dispatch, type ReactElement, type ReactNode, type SetStateAction
+    useCallback,
+    type Dispatch,
+    type ReactElement,
+    type ReactNode,
+    type SetStateAction
 } from "react";
 
 import { Window, type WindowProps } from "window";
 import type { ToolbarState } from "./Toolbar";
 
-export function ToolWindow(
-    { toolbarStateKey, toolbarState, setToolbarState, children, ...windowProps }: ToolWindowProps
-): ReactElement | undefined {
+export function ToolWindow({
+    toolbarStateKey,
+    toolbarState,
+    setToolbarState,
+    children,
+    ...windowProps
+}: ToolWindowProps): ReactElement | undefined {
     const isVisible = toolbarState[toolbarStateKey];
 
     const onClose = useCallback(() => {

--- a/src/samples/window-sample/window-app/tsx/Toolbar.tsx
+++ b/src/samples/window-sample/window-app/tsx/Toolbar.tsx
@@ -5,26 +5,36 @@ import { ToolButton } from "@open-pioneer/map-ui-components";
 import { useIntl } from "open-pioneer:react-hooks";
 import { useCallback, useMemo, type Dispatch, type ReactElement, type SetStateAction } from "react";
 import {
-    PiBookmarkSimpleLight, PiImagesLight, PiListLight, PiPrinterLight, PiRulerLight
+    PiBookmarkSimpleLight,
+    PiImagesLight,
+    PiListLight,
+    PiPrinterLight,
+    PiRulerLight
 } from "react-icons/pi";
 
 export function Toolbar({ state, setState }: ToolbarProps): ReactElement {
     const { formatMessage } = useIntl();
 
-    const toggleState = useCallback((key: keyof ToolbarState) => {
-        setState((state) => ({
-            ...state,
-            [key]: !state[key]
-        }));
-    }, [setState]);
+    const toggleState = useCallback(
+        (key: keyof ToolbarState) => {
+            setState((state) => ({
+                ...state,
+                [key]: !state[key]
+            }));
+        },
+        [setState]
+    );
 
-    const callbacks = useMemo(() => ({
-        toggleBookmarks: () => toggleState("bookmarksAreActive"),
-        toggleLegend: () => toggleState("legendIsActive"),
-        toggleMeasurement: () => toggleState("measurementIsActive"),
-        togglePrinting: () => toggleState("printingIsActive"),
-        toggleToc: () => toggleState("tocIsActive")
-    }), [toggleState]);
+    const callbacks = useMemo(
+        () => ({
+            toggleBookmarks: () => toggleState("bookmarksAreActive"),
+            toggleLegend: () => toggleState("legendIsActive"),
+            toggleMeasurement: () => toggleState("measurementIsActive"),
+            togglePrinting: () => toggleState("printingIsActive"),
+            toggleToc: () => toggleState("tocIsActive")
+        }),
+        [toggleState]
+    );
 
     return (
         <VStack spacing={2}>

--- a/src/samples/window-sample/window-app/tsx/Toolbar.tsx
+++ b/src/samples/window-sample/window-app/tsx/Toolbar.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { VStack } from "@open-pioneer/chakra-integration";
+import { ToolButton } from "@open-pioneer/map-ui-components";
+import { useIntl } from "open-pioneer:react-hooks";
+import { useCallback, useMemo, type Dispatch, type ReactElement, type SetStateAction } from "react";
+import {
+    PiBookmarkSimpleLight, PiImagesLight, PiListLight, PiPrinterLight, PiRulerLight
+} from "react-icons/pi";
+
+export function Toolbar({ state, setState }: ToolbarProps): ReactElement {
+    const { formatMessage } = useIntl();
+
+    const toggleState = useCallback((key: keyof ToolbarState) => {
+        setState((state) => ({
+            ...state,
+            [key]: !state[key]
+        }));
+    }, [setState]);
+
+    const callbacks = useMemo(() => ({
+        toggleBookmarks: () => toggleState("bookmarksAreActive"),
+        toggleLegend: () => toggleState("legendIsActive"),
+        toggleMeasurement: () => toggleState("measurementIsActive"),
+        togglePrinting: () => toggleState("printingIsActive"),
+        toggleToc: () => toggleState("tocIsActive")
+    }), [toggleState]);
+
+    return (
+        <VStack spacing={2}>
+            <ToolButton
+                label={formatMessage({ id: "toolTitle.toc" })}
+                icon={<PiListLight />}
+                isActive={state.tocIsActive}
+                onClick={callbacks.toggleToc}
+            />
+            <ToolButton
+                label={formatMessage({ id: "toolTitle.legend" })}
+                icon={<PiImagesLight />}
+                isActive={state.legendIsActive}
+                onClick={callbacks.toggleLegend}
+            />
+            <ToolButton
+                label={formatMessage({ id: "toolTitle.bookmarks" })}
+                icon={<PiBookmarkSimpleLight />}
+                isActive={state.bookmarksAreActive}
+                onClick={callbacks.toggleBookmarks}
+            />
+            <ToolButton
+                label={formatMessage({ id: "toolTitle.measurement" })}
+                icon={<PiRulerLight />}
+                isActive={state.measurementIsActive}
+                onClick={callbacks.toggleMeasurement}
+            />
+            <ToolButton
+                label={formatMessage({ id: "toolTitle.printing" })}
+                icon={<PiPrinterLight />}
+                isActive={state.printingIsActive}
+                onClick={callbacks.togglePrinting}
+            />
+        </VStack>
+    );
+}
+
+interface ToolbarProps {
+    readonly state: ToolbarState;
+    readonly setState: Dispatch<SetStateAction<ToolbarState>>;
+}
+
+export interface ToolbarState {
+    readonly bookmarksAreActive?: boolean;
+    readonly legendIsActive?: boolean;
+    readonly measurementIsActive?: boolean;
+    readonly printingIsActive?: boolean;
+    readonly tocIsActive?: boolean;
+}

--- a/src/samples/window-sample/window-app/tsx/WindowApp.tsx
+++ b/src/samples/window-sample/window-app/tsx/WindowApp.tsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { Flex } from "@open-pioneer/chakra-integration";
+import { CoordinateViewer } from "@open-pioneer/coordinate-viewer";
+import { DefaultMapProvider, MapAnchor, MapContainer } from "@open-pioneer/map";
+import { Notifier } from "@open-pioneer/notifier";
+import { ScaleBar } from "@open-pioneer/scale-bar";
+import { ScaleViewer } from "@open-pioneer/scale-viewer";
+
+import { useState, type ReactElement } from "react";
+
+import { MAP_ID } from "./MainMapProvider";
+import { MapTool } from "./MapTool";
+import { Toolbar, type ToolbarState } from "./Toolbar";
+
+export function WindowApp(): ReactElement {
+    const [toolbarState, setToolbarState] = useState<ToolbarState>({});
+
+    return (
+        <Flex direction="column" height="full" overflow="hidden">
+            <DefaultMapProvider mapId={MAP_ID}>
+                <Flex direction="column" flex={1}>
+                    <MapContainer>
+                        <MapTool
+                            tool="bookmarks"
+                            toolbarStateKey="bookmarksAreActive"
+                            toolbarState={toolbarState}
+                            setToolbarState={setToolbarState}
+                        />
+                        <MapTool
+                            tool="legend"
+                            toolbarStateKey="legendIsActive"
+                            toolbarState={toolbarState}
+                            setToolbarState={setToolbarState}
+                        />
+                        <MapTool
+                            tool="measurement"
+                            toolbarStateKey="measurementIsActive"
+                            toolbarState={toolbarState}
+                            setToolbarState={setToolbarState}
+                        />
+                        <MapTool
+                            tool="printing"
+                            toolbarStateKey="printingIsActive"
+                            toolbarState={toolbarState}
+                            setToolbarState={setToolbarState}
+                        />
+                        <MapTool
+                            tool="toc"
+                            toolbarStateKey="tocIsActive"
+                            toolbarState={toolbarState}
+                            setToolbarState={setToolbarState}
+                        />
+                        <MapAnchor position="bottom-right" horizontalGap={10} verticalGap={30}>
+                            <Toolbar state={toolbarState} setState={setToolbarState} />
+                        </MapAnchor>
+                    </MapContainer>
+                </Flex>
+                <Flex direction="row" gap={3} alignItems="center" justifyContent="center">
+                    <CoordinateViewer precision={0} />
+                    <ScaleBar />
+                    <ScaleViewer />
+                </Flex>
+            </DefaultMapProvider>
+            <Notifier position="bottom-right" />
+        </Flex>
+    );
+}


### PR DESCRIPTION
This pull request adds a simple windowing system, which is based on [react-rnd](https://github.com/bokuweb/react-rnd), to Open Pioneer.

Windows can be resized from all four corners and all four edges. Their position and size is saved to the browser's local storage to be maintained across app launches. Special consideration is taken for when the browser's window size happens to have changed across launches.

Test this implementation using the following sample: <http://localhost:5173/samples/window-sample/>

([screenshot](https://github.com/user-attachments/assets/8343bef8-05cf-4735-9a55-9b309dc485fa))

