### PR TITLE
[map/group layer]  return nested child layers

### DIFF
--- a/.changeset/cold-radios-fix.md
+++ b/.changeset/cold-radios-fix.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map": minor
+---
+
+Grouplayers are now able to return all nested child layers

--- a/src/packages/map/api/layers/GroupLayer.ts
+++ b/src/packages/map/api/layers/GroupLayer.ts
@@ -50,6 +50,11 @@ export interface GroupLayerCollection extends ChildrenCollection<Layer> {
      * Returns all layers in this collection
      */
     getLayers(options?: LayerRetrievalOptions): Layer[];
+
+    /**
+     * Returns all nested child layers that are not of type group layer
+     */
+    getAllChildLayers(layer?: Layer): Layer[];
 }
 
 export interface GroupLayerConstructor {

--- a/src/packages/map/model/layers/GroupLayerImpl.test.ts
+++ b/src/packages/map/model/layers/GroupLayerImpl.test.ts
@@ -92,3 +92,84 @@ it("throws when adding the same child twice", () => {
             })
     ).toThrowErrorMatchingInlineSnapshot(`[Error: Duplicate item added to a unique collection]`);
 });
+
+it("getAllChildLayers - self", async () => {
+    const sublayers = [
+        new SimpleLayerImpl({
+            id: "member",
+            title: "group member",
+            olLayer: new TileLayer({})
+        })
+    ];
+    const layer = new GroupLayerImpl({
+        id: "test",
+        title: "test",
+        layers: sublayers
+    });
+
+    expect(layer.layers.getAllChildLayers()).toEqual(sublayers);
+});
+
+it("getAllChildLayers - empty", async () => {
+    const layer = new GroupLayerImpl({
+        id: "test",
+        title: "test",
+        layers: []
+    });
+
+    expect(layer.layers.getAllChildLayers()).toEqual([]);
+});
+
+it("getAllChildLayers - groupLayer with nested layers", async () => {
+    const testLayers = [
+        new SimpleLayerImpl({
+            id: "a",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        }),
+        new SimpleLayerImpl({
+            id: "b",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        }),
+        new SimpleLayerImpl({
+            id: "c",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        }),
+        new SimpleLayerImpl({
+            id: "d",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        }),
+        new SimpleLayerImpl({
+            id: "e",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        }),
+        new SimpleLayerImpl({
+            id: "f",
+            title: "Foo",
+            olLayer: new TileLayer({})
+        })
+    ];
+    const sublayer = [
+        new GroupLayerImpl({
+            id: "test",
+            title: "test",
+            layers: testLayers.slice(0, 4)
+        }),
+        new GroupLayerImpl({
+            id: "test",
+            title: "test",
+            layers: testLayers.slice(4, 5)
+        }),
+        testLayers[5] as SimpleLayerImpl
+    ];
+    const layer = new GroupLayerImpl({
+        id: "test",
+        title: "test",
+        layers: sublayer
+    });
+    expect(layer.layers.getAllChildLayers()).toEqual(testLayers);
+});

--- a/src/packages/map/model/layers/GroupLayerImpl.ts
+++ b/src/packages/map/model/layers/GroupLayerImpl.ts
@@ -91,6 +91,21 @@ export class GroupLayerCollectionImpl implements GroupLayerCollection {
     }
 
     /**
+     * Returns all nested child layers that are not of type group layer
+     */
+    getAllChildLayers(layer: Layer = this.#parent): Layer[] {
+        if (layer.type !== "group") return [layer];
+        if (layer.layers.getLayers().length === 0) return [];
+
+        let result: Layer[] = [];
+        layer.layers
+            .getLayers()
+            .forEach((sublayer) => (result = result.concat(this.getAllChildLayers(sublayer))));
+
+        return result;
+    }
+
+    /**
      * Returns a reference to the internal group layer array.
      *
      * NOTE: Do not modify directly!


### PR DESCRIPTION
Group layers can now return all nested child layers that are not of type group layer