### PR TITLE
Configuration option to fetch WMS capabilities

### DIFF
--- a/.changeset/slimy-mails-whisper.md
+++ b/.changeset/slimy-mails-whisper.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map": patch
+---
+
+Added configuration option to fetch WMS capabilities

--- a/src/packages/map/api/layers/WMSLayer.ts
+++ b/src/packages/map/api/layers/WMSLayer.ts
@@ -27,6 +27,11 @@ export interface WMSLayerConfig extends LayerConfig {
      * the WMS Layer manages some of the OpenLayers source options itself.
      */
     sourceOptions?: Partial<WMSSourceOptions>;
+
+    /**
+     * Option to fetch capabilities
+     */
+    fetchCapabilities?: boolean;
 }
 
 /**

--- a/src/packages/map/model/layers/WMSLayerImpl.ts
+++ b/src/packages/map/model/layers/WMSLayerImpl.ts
@@ -35,6 +35,7 @@ export class WMSLayerImpl extends AbstractLayer implements WMSLayer {
 
     #visibleSublayers: ReadonlyReactive<string[]>;
     #sublayersWatch: Resource | undefined;
+    #fetchCapabilities: boolean | undefined;
 
     constructor(config: WMSLayerConfig) {
         const layer = new ImageLayer();
@@ -56,6 +57,7 @@ export class WMSLayerImpl extends AbstractLayer implements WMSLayer {
             }
         });
         this.#url = config.url;
+        this.#fetchCapabilities = config.fetchCapabilities;
         this.#source = source;
         this.#layer = layer;
         this.#sublayers = new SublayersCollectionImpl(constructSublayers(config.sublayers));
@@ -125,6 +127,10 @@ export class WMSLayerImpl extends AbstractLayer implements WMSLayer {
                 }
             }
         };
+
+        if (this.#fetchCapabilities === false) {
+            return;
+        }
 
         this.#fetchWMSCapabilities()
             .then((result: string) => {


### PR DESCRIPTION
A configuration option to fetch WMS capabilites was added. Right now, the capabilities are needed to create the legend. In projects with a high number of WMS layers and no legend the fetching of the capabilities leads to a slow app start and many pending requests.
With this configuration option it can be configured whether the capabilities should be fetched or not.