### PR TITLE
Insert layer at a specific position

### DIFF
--- a/.changeset/chilled-laws-swim.md
+++ b/.changeset/chilled-laws-swim.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map": minor
+---
+
+added ability to add layers in defined positions to the map

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -6,12 +6,12 @@ import type OlView from "ol/View";
 import type OlBaseLayer from "ol/layer/Base";
 import type { ExtentConfig } from "./MapConfig";
 import type { AnyLayer, ChildrenCollection, Layer } from "./layers";
-import type { LayerRetrievalOptions, RecursiveRetrievalOptions } from "./shared";
 import type { Geometry } from "ol/geom";
 import type { BaseFeature } from "./BaseFeature";
 import type { StyleLike } from "ol/style/Style";
 import type { Projection } from "ol/proj";
 import type { Coordinate } from "ol/coordinate";
+import type { AddLayerOptions, LayerRetrievalOptions, RecursiveRetrievalOptions } from "./shared";
 
 /** Events emitted by the {@link MapModel}. */
 export interface MapModelEvents {
@@ -271,9 +271,10 @@ export interface LayerCollection extends ChildrenCollection<Layer> {
      *
      * The new layer is automatically registered with this collection.
      *
-     * NOTE: by default, the new layer will be shown on _top_ of all existing layers.
+     * NOTE: by default, the new layer will be shown on _top_ of all existing layers. Use the `options` parameter to
+     * control the insertion point.
      */
-    addLayer(layer: Layer): void;
+    addLayer(layer: Layer, options?: AddLayerOptions): void;
 
     /**
      * Returns the layer identified by the `id` or undefined, if no such layer exists.

--- a/src/packages/map/api/shared.ts
+++ b/src/packages/map/api/shared.ts
@@ -21,3 +21,38 @@ export interface RecursiveRetrievalOptions extends LayerRetrievalOptions {
      */
     filter?: (layer: AnyLayer) => boolean;
 }
+
+/** These options can be used to insert a new layer at a specific location in the top level hierarchy */
+export type AddLayerOptions =
+    | AddLayerOptionsTopBottom
+    | AddLayerOptionsAboveBelow
+    | AddLayerOptionsIndex;
+
+interface AddLayerOptionsBase {
+    /**
+     * Where to insert the new layer. default: "top"
+     */
+    at: "top" | "bottom" | "index" | "above" | "below";
+}
+
+interface AddLayerOptionsTopBottom extends AddLayerOptionsBase {
+    at: "top" | "bottom";
+}
+
+interface AddLayerOptionsIndex extends AddLayerOptionsBase {
+    at: "index";
+
+    /**
+     * The index at which to insert the new layer. Only used if `at` is "index".
+     */
+    index: number;
+}
+
+interface AddLayerOptionsAboveBelow extends AddLayerOptionsBase {
+    at: "above" | "below";
+
+    /**
+     * The ID of the layer above or below which to insert the new layer. Only used if `at` is "above" or "below".
+     */
+    layerId: string;
+}


### PR DESCRIPTION
For issue #411.

This change to the MapModel.addLayer API, allows the developer to insert a new layer at a specified position. The position can be defined as absolute or relative position to a different layer.
For a project, I implemented this feature the following way:
The developer can provide an option if they want the new layer to be at the "top" (default), "bottom", "above" or "below" a layer with a specific ID, or at an "index" in the top-level hierarchy.

This adds a small overhead, since the zIndex needs to be updated for every layer when a change occurs. However, I don't think any project would ever get near a layer count where a linear scan on an insert or remove would harm performance.

