### PR TITLE
Fix typos across docs and comments

### DIFF
--- a/docs/guidelines/Development.md
+++ b/docs/guidelines/Development.md
@@ -42,7 +42,7 @@
 - Be strict about TypeScript, especially in public interfaces
 - Use TODO keyword only for things that are currently in doing, not for things that should be implemented anytime in the future. Exceptional: special usages determined by the team.
 - If creating a new package that has a name that consists of multiple words, use a dash to connect the words.
-- If adding own CSS classes, always use the package or component name as a prefix in the class name (seperated using a dash). Example: "<b>measurement-</b>tooltip"
+- If adding own CSS classes, always use the package or component name as a prefix in the class name (separated using a dash). Example: "<b>measurement-</b>tooltip"
 
 ## Tests
 

--- a/src/experimental-packages/layout-sidebar/README.md
+++ b/src/experimental-packages/layout-sidebar/README.md
@@ -9,7 +9,7 @@ Currently the sidebar will be positioned absolute in the provided container. The
 - It could be set with boolean (`defaultExpanded`) for default expension.
 - An event `expandedChanged` is triggered when the main section is expanded/collapsed.
 - `sidebarWidthChanged` informs about the current width of the sidebar. So the wrapping component can react on this width.
-- the `items` defined the visible menu entries and their corrensponding content.
+- the `items` define the visible menu entries and their corresponding content.
 
 See this sample for integration:
 

--- a/src/experimental-packages/layout-sidebar/Sidebar.tsx
+++ b/src/experimental-packages/layout-sidebar/Sidebar.tsx
@@ -51,7 +51,7 @@ export interface SidebarProperties {
      */
     sidebarWidthChanged?: (width: number) => void;
     /**
-     * The visible menu entries and their corrensponding content.
+     * The visible menu entries and their corresponding content.
      */
     items?: SidebarItem[];
 }

--- a/src/packages/coordinate-search/i18n/en.yaml
+++ b/src/packages/coordinate-search/i18n/en.yaml
@@ -5,7 +5,7 @@ messages:
     clearPlaceholder: Clear
   tooltip:
     basic: "Invalid input"
-    space: "Invalid input: Please enter the coordinates seperated by a space."
+    space: "Invalid input: Please enter the coordinates separated by a space."
     spaceOne: "Invalid input: Please use exactly one space to separate the coordinates."
     2coords: "Invalid input: Please enter two numbers."
     invalidNumbers: "Invalid input: Please enter two valid numbers."

--- a/src/packages/map/README.md
+++ b/src/packages/map/README.md
@@ -45,12 +45,12 @@ The component itself uses the map registry service to create the map using the p
 
 The MapContainer provides a prop `viewPadding` that allows to set the map's view padding
 (see [padding property on OL View](https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#padding)).
-This prop musst be used to set the views padding instead of directly setting the padding on the
-OL map's view to ensure that map anchor are positioned correctly.
+This prop must be used to set the view's padding instead of directly setting the padding on the
+OL map's view to ensure that map anchors are positioned correctly.
 
 Additionally, using the prop `viewPaddingChangeBehavior` it is possible to specify how the map behaves when the view padding changes.
-Possible values are `none` (no nothing), `preserve-center`(ensures that the center point remains the same
-by animating the view) and `preserve-extent` ´(ensures that the extent remains the same by zooming).
+Possible values are `none` (do nothing), `preserve-center` (ensures that the center point remains the same
+by animating the view) and `preserve-extent` (ensures that the extent remains the same by zooming).
 
 ### Map anchor component
 


### PR DESCRIPTION
## Summary
- fix typo in sidebar package README
- correct spelling in Sidebar.tsx comment
- update tooltip message in coordinate-search package
- correct separated wording in Dev guidelines
- patch map package README typos

## Testing
- `pnpm test` *(fails: EHOSTUNREACH)*