### PR TITLE
Improve scale viewer a11y (#431)

### DIFF
--- a/src/packages/scale-viewer/ScaleViewer.tsx
+++ b/src/packages/scale-viewer/ScaleViewer.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, VisuallyHidden } from "@chakra-ui/react";
 import { MapModelProps, useMapModel } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { useIntl } from "open-pioneer:react-hooks";
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 
 /**
  * These are the properties supported by the {@link ScaleViewer}.
@@ -16,17 +16,40 @@ export const ScaleViewer: FC<ScaleViewerProps> = (props) => {
     const { containerProps } = useCommonComponentProps("scale-viewer", props);
     const { map } = useMapModel(props);
     const intl = useIntl();
+
     const scale = useReactiveSnapshot(() => map?.scale ?? 1, [map]);
-    const displayScale = scale ? intl.formatNumber(scale) : undefined;
-    const ariaLabel = scale ? intl.formatMessage({ id: "scaleLabel" }, { scale }) : undefined;
+    const displayScale = intl.formatNumber(scale);
+
+    // Make the scale shown to the screen reader lag behind a bit via debounce.
+    // Otherwise, the user is notified of too many updates (individual scale changes).
+    // See https://github.com/open-pioneer/trails-openlayers-base-packages/issues/431
+    const debouncedScale = useDebouncedValue(scale);
+    const ariaLabel = intl.formatMessage({ id: "scaleLabel" }, { scale: debouncedScale });
 
     return (
-        <Box {...containerProps}>
-            {displayScale && (
-                <Text as="p" aria-live="polite" role="region" aria-label={ariaLabel}>
-                    <span aria-hidden="true">1:{displayScale}</span>
-                </Text>
-            )}
+        <Box
+            {...containerProps}
+            role="region"
+            aria-label={intl.formatMessage({ id: "regionLabel" })}
+        >
+            <VisuallyHidden aria-live="polite" aria-atomic="true">
+                {ariaLabel}
+            </VisuallyHidden>
+            <Text as="p" aria-hidden="true">
+                1:{displayScale}
+            </Text>
         </Box>
     );
 };
+
+// TODO: Might be useful in a shared package
+function useDebouncedValue<T>(currentValue: T, timeout = 1000): T {
+    const [value, setValue] = useState<T>(currentValue);
+
+    useEffect(() => {
+        const id = setTimeout(() => setValue(currentValue), timeout);
+        return () => clearTimeout(id);
+    }, [currentValue, timeout]);
+
+    return value;
+}

--- a/src/packages/scale-viewer/__snapshots__/ScaleViewer.test.tsx.snap
+++ b/src/packages/scale-viewer/__snapshots__/ScaleViewer.test.tsx.snap
@@ -2,42 +2,48 @@
 
 exports[`should successfully create a scale viewer component 1`] = `
 <div
+  aria-label="regionLabel"
   class="scale-viewer css-0"
   data-testid="scale-viewer"
+  role="region"
 >
-  <p
-    aria-label="scaleLabel"
+  <span
+    aria-atomic="true"
     aria-live="polite"
-    class="css-0"
-    role="region"
+    class="css-cfk6a1"
   >
-    <span
-      aria-hidden="true"
-    >
-      1:
-      336,409
-    </span>
+    scaleLabel
+  </span>
+  <p
+    aria-hidden="true"
+    class="css-0"
+  >
+    1:
+    336,409
   </p>
 </div>
 `;
 
 exports[`should successfully create a scale viewer component with additional css classes and box properties 1`] = `
 <div
+  aria-label="regionLabel"
   class="scale-viewer test test1 test2 css-0"
   data-testid="scale-viewer"
+  role="region"
 >
-  <p
-    aria-label="scaleLabel"
+  <span
+    aria-atomic="true"
     aria-live="polite"
-    class="css-0"
-    role="region"
+    class="css-cfk6a1"
   >
-    <span
-      aria-hidden="true"
-    >
-      1:
-      336,409
-    </span>
+    scaleLabel
+  </span>
+  <p
+    aria-hidden="true"
+    class="css-0"
+  >
+    1:
+    336,409
   </p>
 </div>
 `;

--- a/src/packages/scale-viewer/i18n/de.yaml
+++ b/src/packages/scale-viewer/i18n/de.yaml
@@ -1,2 +1,3 @@
 messages:
-  scaleLabel: 'Aktueller Maßstab: 1 zu {scale, number}'
+  regionLabel: "Maßstab"
+  scaleLabel: "Aktueller Maßstab: 1 zu {scale}"

--- a/src/packages/scale-viewer/i18n/en.yaml
+++ b/src/packages/scale-viewer/i18n/en.yaml
@@ -1,2 +1,3 @@
 messages:
-  scaleLabel: 'Current scale: 1 to {scale, number}'
+  regionLabel: "Scale"
+  scaleLabel: "Current scale: 1 to {scale}"


### PR DESCRIPTION
Issue: #431

Change implementation approach:
- Use a visually hidden element containing the screen reader message (live region)
- Debounce scale by 1 second to reduce the number of announcements