### PR TITLE
add layer property to hide certain layers in TOC

### DIFF
--- a/.changeset/few-ducks-try.md
+++ b/.changeset/few-ducks-try.md
@@ -14,7 +14,7 @@ const internalLayer = new SimpleLayer({
 });
 ```
 
-The layer's `internal` state does also affect other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
+The layer's `internal` state also affects other UI widgets (e.g. Legend). If the layer should be hidden specifically in the toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
 
 ```typescript
 //use listMode to hide the layer specifically in Toc

--- a/.changeset/few-ducks-try.md
+++ b/.changeset/few-ducks-try.md
@@ -1,0 +1,39 @@
+---
+"@open-pioneer/toc": minor
+---
+
+Layers that are marked as `internal` are not considered by the Toc.
+
+```typescript
+//internal layer will not be displayed in the Toc
+const internalLayer = new SimpleLayer({
+    id: "layer1",
+    title: "layer 1",
+    olLayer: myOlLayer,
+    internal: true
+});
+```
+
+The layer's `internal` state does also affect other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
+
+```typescript
+//use listMode to hide the layer specifically in Toc
+const hiddenLayer = new SimpleLayer({
+    id: "layer1",
+    title: "layer 1",
+    olLayer: myOlLayer,
+    attributes: {
+        toc: {
+            listMode: "hide"
+        }
+    }
+});
+```
+
+Valid values for `listMode` are:
+
+- `"show"` layer item is displayed in Toc
+- `"hide"` layer item is not rendered in Toc
+- `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
+
+The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.

--- a/.changeset/few-ducks-try.md
+++ b/.changeset/few-ducks-try.md
@@ -36,4 +36,4 @@ Valid values for `listMode` are:
 - `"hide"` layer item is not rendered in Toc
 - `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
 
-The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
+The `listMode` does always have precedence over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.

--- a/.changeset/giant-humans-rest.md
+++ b/.changeset/giant-humans-rest.md
@@ -1,0 +1,16 @@
+---
+"@open-pioneer/map": minor
+---
+
+Introduce `internal` property for all layer types (including sublayers). If `internal` is `true` (default: `false`) the layer is not considered by any UI widget (e.g Legend and Toc). The `internal` state of a layer is not to be confused with the layer's visibilty on the map which is determined by the `visible` property.
+
+```typescript
+//internal layer is visible on the map but hidden in the Toc
+const internalLayer = new SimpleLayer({
+    id: "layer1",
+    title: "layer 1",
+    olLayer: myOlLayer,
+    visible: true,
+    internal: true
+});
+```

--- a/.changeset/giant-humans-rest.md
+++ b/.changeset/giant-humans-rest.md
@@ -2,10 +2,10 @@
 "@open-pioneer/map": minor
 ---
 
-Introduce `internal` property for all layer types (including sublayers). If `internal` is `true` (default: `false`) the layer is not considered by any UI widget (e.g Legend and Toc). The `internal` state of a layer is not to be confused with the layer's visibilty on the map which is determined by the `visible` property.
+Introduce `internal` property for all layer types (including sublayers). If `internal` is `true` (default: `false`) the layer is not considered by any UI widget (e.g. legend and Toc). The `internal` state of a layer is not to be confused with the layer's visibility on the map which is determined by the `visible` property.
 
 ```typescript
-//internal layer is visible on the map but hidden in the Toc
+//internal layer is visible on the map but hidden in UI elements like legend and Toc
 const internalLayer = new SimpleLayer({
     id: "layer1",
     title: "layer 1",

--- a/.changeset/soft-tools-knock.md
+++ b/.changeset/soft-tools-knock.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/legend": minor
+---
+
+A layer's `internal` property is now respected by the Legend widget. If a layer is marked as internal (`internal` is `true`) no legend entry is displayed for this layer even it the legend is configured in the layer attributes.

--- a/.changeset/soft-tools-knock.md
+++ b/.changeset/soft-tools-knock.md
@@ -2,4 +2,4 @@
 "@open-pioneer/legend": minor
 ---
 
-A layer's `internal` property is now respected by the Legend widget. If a layer is marked as internal (`internal` is `true`) no legend entry is displayed for this layer even it the legend is configured in the layer attributes.
+A layer's `internal` property is now respected by the Legend widget. If a layer is marked as internal (`internal` is `true`) no legend entry is displayed for this layer even if the legend is configured in the layer attributes.

--- a/src/packages/legend/Legend.tsx
+++ b/src/packages/legend/Legend.tsx
@@ -90,10 +90,10 @@ function LegendList(props: { map: MapModel; showBaseLayers: boolean }): ReactNod
 
 function LegendItem(props: { layer: AnyLayer; showBaseLayers: boolean }): ReactNode {
     const { layer, showBaseLayers } = props;
-    const isVisible = useReactiveSnapshot(() => layer.visible, [layer]);
+    const { isVisible, isInternal } = useReactiveSnapshot(() => { return { isVisible: layer.visible, isInternal: layer.internal }; }, [layer]);
     const childLayers = useChildLayers(layer);
 
-    if (!isVisible) {
+    if (!isVisible || isInternal) {
         return undefined;
     }
 

--- a/src/packages/legend/Legend.tsx
+++ b/src/packages/legend/Legend.tsx
@@ -90,7 +90,9 @@ function LegendList(props: { map: MapModel; showBaseLayers: boolean }): ReactNod
 
 function LegendItem(props: { layer: AnyLayer; showBaseLayers: boolean }): ReactNode {
     const { layer, showBaseLayers } = props;
-    const { isVisible, isInternal } = useReactiveSnapshot(() => { return { isVisible: layer.visible, isInternal: layer.internal }; }, [layer]);
+    const { isVisible, isInternal } = useReactiveSnapshot(() => {
+        return { isVisible: layer.visible, isInternal: layer.internal };
+    }, [layer]);
     const childLayers = useChildLayers(layer);
 
     if (!isVisible || isInternal) {

--- a/src/packages/legend/README.md
+++ b/src/packages/legend/README.md
@@ -70,6 +70,7 @@ Showing legend entries is also supported for **sublayers** (configuration and au
 The legend content for sublayers is shown plain and without hierarchical structure in the Legend UI.
 
 #### Internal layers
+
 If a layer is marked as internal (layer's `internal` property is `true`) it will not be considered in the legend widget. Even if a legend is configured it will no be displayed. The `internal` property does also affect other UI widgets (e.g Toc).
 
 ### Showing legend for basemap

--- a/src/packages/legend/README.md
+++ b/src/packages/legend/README.md
@@ -69,6 +69,9 @@ If a configuration is done, it supersedes the automatic legend retrieval.
 Showing legend entries is also supported for **sublayers** (configuration and automatic retrieval).
 The legend content for sublayers is shown plain and without hierarchical structure in the Legend UI.
 
+#### Internal layers
+If a layer is marked as internal (layer's `internal` property is `true`) it will not be considered in the legend widget. Even if a legend is configured it will no be displayed. The `internal` property does also affect other UI widgets (e.g Toc).
+
 ### Showing legend for basemap
 
 By default, the legend for the active basemap is not shown.

--- a/src/packages/legend/README.md
+++ b/src/packages/legend/README.md
@@ -71,7 +71,7 @@ The legend content for sublayers is shown plain and without hierarchical structu
 
 #### Internal layers
 
-If a layer is marked as internal (layer's `internal` property is `true`) it will not be considered in the legend widget. Even if a legend is configured it will no be displayed. The `internal` property does also affect other UI widgets (e.g Toc).
+If a layer is marked as internal (layer's `internal` property is `true`) it will not be considered in the legend widget. Even if a legend is configured it will not be displayed. The `internal` property also affects other UI widgets (e.g. Toc).
 
 ### Showing legend for basemap
 

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -140,10 +140,10 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
     readonly sublayers: SublayersCollection | undefined;
 
     /**
-     * The internal state of this layer. Internal layers are not considered by any UI widget (e.g Toc or Legend).
+     * The internal property of this layer. Internal layers are not considered by any UI widget (e.g Toc or Legend).
      * The internal state is independent of the layer's visibility which is determined by {@link visible}
      *
-     * NOTE: Some UI widgets might use component specific {@link attributes} that have precedence over the internal state.
+     * NOTE: Some UI widgets might use component specific {@link attributes} that have precedence over the internal property.
      */
     readonly internal: boolean;
 
@@ -171,7 +171,7 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
     setVisible(newVisibility: boolean): void;
 
     /**
-     * Updates the internal state of this layer to the new value.
+     * Updates the internal property of this layer to the new value.
      * @param newIsInternal
      */
     setInternal(newIsInternal: boolean): void;

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -20,6 +20,8 @@ export type LayerLoadState = "not-loaded" | "loading" | "loaded" | "error";
 /** Custom function to check the state of a layer and returning a "loaded" or "error". */
 export type HealthCheckFunction = (layer: Layer) => Promise<"loaded" | "error">;
 
+export type DisplayMode = "show" | "hide" | "hide_children";
+
 /**
  * Configuration options supported by all layer types (layers and sublayers).
  */
@@ -52,6 +54,8 @@ export interface LayerBaseConfig {
      * These can be arbitrary values.
      */
     attributes?: Record<string | symbol, unknown>;
+
+    displayMode?: DisplayMode;
 }
 
 /**
@@ -137,6 +141,10 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
      * Additional attributes associated with this layer.
      */
     readonly attributes: Readonly<Record<string | symbol, unknown>>;
+
+    readonly displayMode: DisplayMode;
+
+    setDisplayMode(newDisplayMode: string): void;
 
     /**
      * Updates the title of this layer.

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -20,8 +20,6 @@ export type LayerLoadState = "not-loaded" | "loading" | "loaded" | "error";
 /** Custom function to check the state of a layer and returning a "loaded" or "error". */
 export type HealthCheckFunction = (layer: Layer) => Promise<"loaded" | "error">;
 
-export type DisplayMode = "show" | "hide" | "hide_children";
-
 /**
  * Configuration options supported by all layer types (layers and sublayers).
  */
@@ -58,7 +56,7 @@ export interface LayerBaseConfig {
     /**
      * Whether this layer should be considered by map components (e.g TOC)
      */
-    displayMode?: DisplayMode;
+    internal?: boolean;
 }
 
 /**
@@ -145,9 +143,9 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
      */
     readonly attributes: Readonly<Record<string | symbol, unknown>>;
 
-    readonly displayMode: DisplayMode;
+    readonly internal: boolean;
 
-    setDisplayMode(newDisplayMode: string): void;
+    setInternal(newIsInternal: boolean): void;
 
     /**
      * Updates the title of this layer.

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -55,6 +55,9 @@ export interface LayerBaseConfig {
      */
     attributes?: Record<string | symbol, unknown>;
 
+    /**
+     * Whether this layer should be considered by map components (e.g TOC)
+     */
     displayMode?: DisplayMode;
 }
 

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -54,7 +54,7 @@ export interface LayerBaseConfig {
     attributes?: Record<string | symbol, unknown>;
 
     /**
-     * Layers marked as internal are not considered by any UI widget (e.g Toc or Legend)
+     * Layers marked as internal are not considered by any UI widget (e.g. Toc or Legend)
      * Defaults to `false`
      */
     internal?: boolean;
@@ -140,10 +140,10 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
     readonly sublayers: SublayersCollection | undefined;
 
     /**
-     * The internal property of this layer. Internal layers are not considered by any UI widget (e.g Toc or Legend).
+     * Property that specifies if the layer is an "internal" layer. Internal layers are not considered by any UI widget (e.g. Toc or Legend).
      * The internal state is independent of the layer's visibility which is determined by {@link visible}
      *
-     * NOTE: Some UI widgets might use component specific {@link attributes} that have precedence over the internal property.
+     * NOTE: Some UI widgets might use component specific attributes or props that have precedence over the internal property.
      */
     readonly internal: boolean;
 

--- a/src/packages/map/api/layers/base.ts
+++ b/src/packages/map/api/layers/base.ts
@@ -54,7 +54,8 @@ export interface LayerBaseConfig {
     attributes?: Record<string | symbol, unknown>;
 
     /**
-     * Whether this layer should be considered by map components (e.g TOC)
+     * Layers marked as internal are not considered by any UI widget (e.g Toc or Legend)
+     * Defaults to `false`
      */
     internal?: boolean;
 }
@@ -139,13 +140,17 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
     readonly sublayers: SublayersCollection | undefined;
 
     /**
+     * The internal state of this layer. Internal layers are not considered by any UI widget (e.g Toc or Legend).
+     * The internal state is independent of the layer's visibility which is determined by {@link visible}
+     *
+     * NOTE: Some UI widgets might use component specific {@link attributes} that have precedence over the internal state.
+     */
+    readonly internal: boolean;
+
+    /**
      * Additional attributes associated with this layer.
      */
     readonly attributes: Readonly<Record<string | symbol, unknown>>;
-
-    readonly internal: boolean;
-
-    setInternal(newIsInternal: boolean): void;
 
     /**
      * Updates the title of this layer.
@@ -164,6 +169,12 @@ export interface AnyLayerBaseType<AdditionalEvents = {}>
      * Call {@link LayerCollection.activateBaseLayer} instead.
      */
     setVisible(newVisibility: boolean): void;
+
+    /**
+     * Updates the internal state of this layer to the new value.
+     * @param newIsInternal
+     */
+    setInternal(newIsInternal: boolean): void;
 
     /**
      * Updates the attributes of this layer.

--- a/src/packages/map/model/AbstractLayer.test.ts
+++ b/src/packages/map/model/AbstractLayer.test.ts
@@ -56,6 +56,31 @@ it("supports the visibility attribute", async () => {
     expect(layer.olLayer.getVisible()).toBe(true);
 });
 
+it("manages the internal attribute", async () => {
+    const { layer } = createLayer({
+        id: "a",
+        title: "A",
+        olLayer: new TileLayer({})
+    });
+    expect(layer.internal).toBe(false); //should be false by default
+
+    let changedInternalState = 0;
+    syncWatch(
+        () => [layer.internal],
+        () => {
+            ++changedInternalState;
+        }
+    );
+
+    layer.setInternal(true);
+    expect(changedInternalState).toBe(1);
+    expect(layer.internal).toBe(true);
+
+    layer.setInternal(false);
+    expect(changedInternalState).toBe(2);
+    expect(layer.internal).toBe(false);
+});
+
 it("logs a warning when setVisible() is called on a base layer", async () => {
     const logSpy = vi.spyOn(global.console, "warn").mockImplementation(() => undefined);
     const { layer } = createLayer({

--- a/src/packages/map/model/AbstractLayerBase.ts
+++ b/src/packages/map/model/AbstractLayerBase.ts
@@ -15,6 +15,7 @@ import {
     AnyLayerBaseType,
     AnyLayerTypes,
     ChildrenCollection,
+    DisplayMode,
     LayerBaseEvents,
     Sublayer
 } from "../api";
@@ -30,6 +31,7 @@ export interface AbstractLayerBaseOptions {
     title: string;
     description?: string;
     attributes?: Record<string, unknown>;
+    displayMode?: DisplayMode;
 }
 
 /**
@@ -49,6 +51,7 @@ export abstract class AbstractLayerBase<AdditionalEvents = {}>
     #attributesMap = reactiveMap<string | symbol, unknown>();
     #attributes: ReadonlyReactive<Record<string | symbol, unknown>>;
     #destroyed = false;
+    #displayMode: Reactive<DisplayMode>;
 
     constructor(config: AbstractLayerBaseOptions) {
         super();
@@ -58,10 +61,19 @@ export abstract class AbstractLayerBase<AdditionalEvents = {}>
         });
         this.#title = reactive(config.title);
         this.#description = reactive(config.description ?? "");
+        this.#displayMode = reactive(config.displayMode ?? "show");
 
         if (config.attributes) {
             this.updateAttributes(config.attributes);
         }
+    }
+
+    get displayMode(): DisplayMode {
+        return this.#displayMode.value;
+    }
+
+    setDisplayMode(newDisplayMode: DisplayMode): void {
+        this.#displayMode.value = newDisplayMode;
     }
 
     protected get __destroyed(): boolean {

--- a/src/packages/map/model/AbstractLayerBase.ts
+++ b/src/packages/map/model/AbstractLayerBase.ts
@@ -15,7 +15,6 @@ import {
     AnyLayerBaseType,
     AnyLayerTypes,
     ChildrenCollection,
-    DisplayMode,
     LayerBaseEvents,
     Sublayer
 } from "../api";
@@ -23,6 +22,7 @@ import { GroupLayer } from "../api/layers/GroupLayer";
 import { GroupLayerCollectionImpl } from "./layers/GroupLayerImpl";
 import { MapModelImpl } from "./MapModelImpl";
 import { SublayersCollectionImpl } from "./SublayersCollectionImpl";
+import { b } from "vitest/dist/chunks/mocker.d.BE_2ls6u.js";
 
 const LOG = createLogger("map:AbstractLayerModel");
 
@@ -31,7 +31,7 @@ export interface AbstractLayerBaseOptions {
     title: string;
     description?: string;
     attributes?: Record<string, unknown>;
-    displayMode?: DisplayMode;
+    internal?: boolean;
 }
 
 /**
@@ -51,7 +51,7 @@ export abstract class AbstractLayerBase<AdditionalEvents = {}>
     #attributesMap = reactiveMap<string | symbol, unknown>();
     #attributes: ReadonlyReactive<Record<string | symbol, unknown>>;
     #destroyed = false;
-    #displayMode: Reactive<DisplayMode>;
+    #internal: Reactive<boolean>;
 
     constructor(config: AbstractLayerBaseOptions) {
         super();
@@ -61,19 +61,19 @@ export abstract class AbstractLayerBase<AdditionalEvents = {}>
         });
         this.#title = reactive(config.title);
         this.#description = reactive(config.description ?? "");
-        this.#displayMode = reactive(config.displayMode ?? "show");
+        this.#internal = reactive(config.internal ?? false);
 
         if (config.attributes) {
             this.updateAttributes(config.attributes);
         }
     }
 
-    get displayMode(): DisplayMode {
-        return this.#displayMode.value;
+    get internal(): boolean {
+        return this.#internal.value;
     }
 
-    setDisplayMode(newDisplayMode: DisplayMode): void {
-        this.#displayMode.value = newDisplayMode;
+    setInternal(newIsInternal: boolean): void {
+        this.#internal.value = newIsInternal;
     }
 
     protected get __destroyed(): boolean {

--- a/src/packages/map/model/AbstractLayerBase.ts
+++ b/src/packages/map/model/AbstractLayerBase.ts
@@ -22,7 +22,6 @@ import { GroupLayer } from "../api/layers/GroupLayer";
 import { GroupLayerCollectionImpl } from "./layers/GroupLayerImpl";
 import { MapModelImpl } from "./MapModelImpl";
 import { SublayersCollectionImpl } from "./SublayersCollectionImpl";
-import { b } from "vitest/dist/chunks/mocker.d.BE_2ls6u.js";
 
 const LOG = createLogger("map:AbstractLayerModel");
 

--- a/src/packages/toc/README.md
+++ b/src/packages/toc/README.md
@@ -95,6 +95,7 @@ If enabled, a toggle button appears next to parent nodes by which the user can e
 ### Hide certain layers in Toc
 
 Layers that are marked as `internal` are not considered by the Toc.
+
 ```typescript
 //internal layer will not be displayed in the Toc
 const internalLayer = new SimpleLayer({
@@ -104,7 +105,9 @@ const internalLayer = new SimpleLayer({
     internal: true
 });
 ```
+
 The layer's `internal` state does also affect other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
+
 ```typescript
 //use listMode to hide the layer specifically in Toc
 const hiddenLayer = new SimpleLayer({
@@ -118,12 +121,14 @@ const hiddenLayer = new SimpleLayer({
     }
 });
 ```
-Valid values for `listMode` are:
- - `"show"` layer item is displayed in Toc
- - `"hide"` layer item is not rendered in Toc
- - `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
 
- The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
+Valid values for `listMode` are:
+
+- `"show"` layer item is displayed in Toc
+- `"hide"` layer item is not rendered in Toc
+- `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
+
+The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
 
 ## License
 

--- a/src/packages/toc/README.md
+++ b/src/packages/toc/README.md
@@ -106,7 +106,7 @@ const internalLayer = new SimpleLayer({
 });
 ```
 
-The layer's `internal` state does also affect other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
+The layer's `internal` state also affects other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
 
 ```typescript
 //use listMode to hide the layer specifically in Toc
@@ -128,7 +128,7 @@ Valid values for `listMode` are:
 - `"hide"` layer item is not rendered in Toc
 - `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
 
-The `listMode` does always have precedence over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
+The `listMode` always has precedence over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
 
 ## License
 

--- a/src/packages/toc/README.md
+++ b/src/packages/toc/README.md
@@ -128,7 +128,7 @@ Valid values for `listMode` are:
 - `"hide"` layer item is not rendered in Toc
 - `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
 
-The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
+The `listMode` does always have precedence over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
 
 ## License
 

--- a/src/packages/toc/README.md
+++ b/src/packages/toc/README.md
@@ -92,6 +92,39 @@ If enabled, a toggle button appears next to parent nodes by which the user can e
 />
 ```
 
+### Hide certain layers in Toc
+
+Layers that are marked as `internal` are not considered by the Toc.
+```typescript
+//internal layer will not be displayed in the Toc
+const internalLayer = new SimpleLayer({
+    id: "layer1",
+    title: "layer 1",
+    olLayer: myOlLayer,
+    internal: true
+});
+```
+The layer's `internal` state does also affect other UI widgets (e.g. Legend). If the layer should be hidden specifically in the Toc (but not in other widgets) the `listMode` attribute can be used to hide the layer item.
+```typescript
+//use listMode to hide the layer specifically in Toc
+const hiddenLayer = new SimpleLayer({
+    id: "layer1",
+    title: "layer 1",
+    olLayer: myOlLayer,
+    attributes: {
+        toc: {
+            listMode: "hide"
+        }
+    }
+});
+```
+Valid values for `listMode` are:
+ - `"show"` layer item is displayed in Toc
+ - `"hide"` layer item is not rendered in Toc
+ - `"hide-children"` layer item for the layer itself is displayed in Toc but no layer items for child layers (e.g. sublayers of a group) are rendered
+
+ The `listMode` does always have precedences over the layer's `internal` property. For example, if the `listMode` is `"show"` the layer item is displayed even if `internal` is `true`.
+
 ## License
 
 Apache-2.0 (see `LICENSE` file)

--- a/src/packages/toc/index.ts
+++ b/src/packages/toc/index.ts
@@ -4,6 +4,6 @@ export {
     Toc,
     type TocProps,
     type ToolsConfig,
-    type LayerItemAttributes,
+    type LayerTocAttributes,
     type ListMode
 } from "./ui/Toc";

--- a/src/packages/toc/index.ts
+++ b/src/packages/toc/index.ts
@@ -1,3 +1,9 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-export { Toc, type TocProps, type ToolsConfig } from "./ui/Toc";
+export {
+    Toc,
+    type TocProps,
+    type ToolsConfig,
+    type LayerItemAttributes,
+    type ListMode
+} from "./ui/Toc";

--- a/src/packages/toc/ui/LayerList/LayerItem.tsx
+++ b/src/packages/toc/ui/LayerList/LayerItem.tsx
@@ -54,12 +54,12 @@ export const LayerItem = memo(function LayerItem(props: { layer: AnyLayer }): Re
     const nestedChildren = useNestedChildren(layerGroupId, title, layer, intl);
     let hasNestedChildren = !!nestedChildren;
 
-    //hidden => do not render toc entry for list item
+    //hidden => do not render toc entry for layer item
     if (displayMode === "hide") {
         return null;
     }
     //all children hidden => do not render collapse button and child entries
-    if (displayMode === "hide_children" || !allChildrenHidden) {
+    if (displayMode === "hide_children" || allChildrenHidden) {
         hasNestedChildren = false;
     }
 

--- a/src/packages/toc/ui/LayerList/LayerItem.tsx
+++ b/src/packages/toc/ui/LayerList/LayerItem.tsx
@@ -24,7 +24,7 @@ import { slug } from "../../utils/slug";
 import { useChildLayers, useLoadState } from "./hooks";
 import { LayerItemMenu } from "./LayerItemMenu";
 import { LayerList } from "./LayerList";
-import { LayerItemAttributes } from "../Toc";
+import { LayerTocAttributes } from "../Toc";
 
 /**
  * Renders a single layer as a list item.
@@ -220,9 +220,9 @@ function useTocItem(layer: AnyLayer) {
     return [tocItem, tocModel, options] as const;
 }
 
-function useListMode(layer: AnyLayer): LayerItemAttributes | undefined {
+function useListMode(layer: AnyLayer): LayerTocAttributes | undefined {
     return useReactiveSnapshot(
-        () => layer.attributes.toc as LayerItemAttributes | undefined,
+        () => layer.attributes.toc as LayerTocAttributes | undefined,
         [layer]
     );
 }
@@ -235,6 +235,7 @@ function updateLayerVisibility(layer: AnyLayer, visible: boolean, autoShowParent
 }
 
 /**
+ * Checks if at least on child layer of the given layer exists and should be displayed.
  * @param layer
  * @returns true if at least one child layer's display mode is not `hide`
  */
@@ -250,13 +251,11 @@ function hasShownChildren(layer: AnyLayer): boolean {
 }
 
 /**
- * @param isInternal
- * @param listMode
- * @returns
+ * Checks if a layer should be displayed in the Toc.
  */
 function displayLayerItem(layer: AnyLayer): boolean {
     const isInternal = layer.internal;
-    const listMode = (layer.attributes.toc as LayerItemAttributes | undefined)?.listMode;
+    const listMode = (layer.attributes.toc as LayerTocAttributes | undefined)?.listMode;
 
     if (listMode === "show" || listMode === "hide-children") {
         return true;

--- a/src/packages/toc/ui/LayerList/LayerItem.tsx
+++ b/src/packages/toc/ui/LayerList/LayerItem.tsx
@@ -40,13 +40,13 @@ export const LayerItem = memo(function LayerItem(props: { layer: AnyLayer }): Re
     const layerGroupId = useId();
     const isAvailable = useLoadState(layer) !== "error";
     const notAvailableLabel = intl.formatMessage({ id: "layerNotAvailable" });
-    const { title, description, isVisible, displayMode, allChildrenHidden } =
+    const { title, description, isVisible, isInternal, allChildrenHidden } =
         useReactiveSnapshot(() => {
             return {
                 title: layer.title,
                 description: layer.description,
                 isVisible: layer.visible,
-                displayMode: layer.displayMode,
+                isInternal: layer.internal,
                 allChildrenHidden: !hasShownChildren(layer) //re-evaluates if a child layer's display mode changes
             };
         }, [layer]);
@@ -55,11 +55,11 @@ export const LayerItem = memo(function LayerItem(props: { layer: AnyLayer }): Re
     let hasNestedChildren = !!nestedChildren;
 
     //hidden => do not render toc entry for layer item
-    if (displayMode === "hide") {
+    if (isInternal) {
         return null;
     }
     //all children hidden => do not render collapse button and child entries
-    if (displayMode === "hide_children" || allChildrenHidden) {
+    if (allChildrenHidden) {
         hasNestedChildren = false;
     }
 
@@ -234,6 +234,6 @@ function hasShownChildren(layer: AnyLayer): boolean {
     if (!layer.children || layer.children.getItems().length === 0) {
         return false;
     } else {
-        return layer.children.getItems().some((childLayer) => childLayer.displayMode !== "hide");
+        return layer.children.getItems().some((childLayer) => childLayer.internal === false);
     }
 }

--- a/src/packages/toc/ui/LayerList/LayerItem.tsx
+++ b/src/packages/toc/ui/LayerList/LayerItem.tsx
@@ -122,7 +122,7 @@ export const LayerItem = memo(function LayerItem(props: { layer: AnyLayer }): Re
                 <Spacer />
                 <LayerItemMenu layer={layer} title={title} description={description} intl={intl} />
             </Flex>
-            {nestedChildren && (
+            {hasNestedChildren && (
                 <Collapsible.Root open={expanded} className="toc-collapsible-item">
                     <CollapsibleContent>{nestedChildren}</CollapsibleContent>
                 </Collapsible.Root>

--- a/src/packages/toc/ui/LayerList/LayerList.test.tsx
+++ b/src/packages/toc/ui/LayerList/LayerList.test.tsx
@@ -7,7 +7,6 @@ import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 import {
     fireEvent,
     queryAllByRole,
-    queryByLabelText,
     queryByRole,
     render,
     screen,

--- a/src/packages/toc/ui/LayerList/LayerList.test.tsx
+++ b/src/packages/toc/ui/LayerList/LayerList.test.tsx
@@ -665,15 +665,15 @@ it("displays the layer item only if the layer is not internal", async () => {
         wrapper: createWrapper()
     });
 
-    let itemLabel = queryByLabelText(container, layer.title, { selector: "label" });
-    expect(itemLabel).toBeTruthy();
+    let layerItem = findLayerItem(container, layer.id);
+    expect(layerItem).toBeTruthy();
 
     await act(async () => {
         layer.setInternal(true); //make layer internal
         await nextTick();
     });
-    itemLabel = queryByLabelText(container, layer.title); //layer item should not be there anymore
-    expect(itemLabel).toBeFalsy();
+    layerItem = findLayerItem(container, layer.id); //layer item should not be there anymore
+    expect(layerItem).toBeFalsy();
 });
 
 it("displays the layer item only if the list mode is not `hide`", async () => {
@@ -703,16 +703,16 @@ it("displays the layer item only if the list mode is not `hide`", async () => {
         wrapper: createWrapper()
     });
 
-    let itemLabel = queryByLabelText(container, layer.title, { selector: "label" });
-    expect(itemLabel).toBeTruthy();
+    let layerItem = findLayerItem(container, layer.id);
+    expect(layerItem).toBeTruthy();
 
     await act(async () => {
         layer.setInternal(true); //make layer internal
         await nextTick();
     });
     //layer item should still be there because toc specific listMode has precendences over internal attribute
-    itemLabel = queryByLabelText(container, layer.title, { selector: "label" });
-    expect(itemLabel).toBeTruthy();
+    layerItem = findLayerItem(container, layer.id);
+    expect(layerItem).toBeTruthy();
 
     await act(async () => {
         layer.setInternal(false);
@@ -724,8 +724,8 @@ it("displays the layer item only if the list mode is not `hide`", async () => {
         await nextTick();
     });
     //layer item should still be there because `hide-children` should not affect the layer item itself
-    itemLabel = queryByLabelText(container, layer.title, { selector: "label" });
-    expect(itemLabel).toBeTruthy();
+    layerItem = findLayerItem(container, layer.id);
+    expect(layerItem).toBeTruthy();
 
     await act(async () => {
         layer.updateAttributes({
@@ -735,8 +735,8 @@ it("displays the layer item only if the list mode is not `hide`", async () => {
         });
         await nextTick();
     });
-    itemLabel = queryByLabelText(container, layer.title, { selector: "label" });
-    expect(itemLabel).toBeFalsy();
+    layerItem = findLayerItem(container, layer.id);
+    expect(layerItem).toBeFalsy();
 });
 
 it("does not display layer item for child layer if the group's listMode is `hide-children`", async () => {
@@ -768,10 +768,10 @@ it("does not display layer item for child layer if the group's listMode is `hide
         wrapper: createWrapper()
     });
 
-    let groupItemLabel = queryByLabelText(container, groupLayer.title, { selector: "label" });
-    expect(groupItemLabel).toBeTruthy();
-    let childItemLabel = queryByLabelText(container, childLayer.title, { selector: "label" });
-    expect(childItemLabel).toBeTruthy();
+    let groupLayerItem = findLayerItem(container, groupLayer.id);
+    expect(groupLayerItem).toBeTruthy();
+    let childLayerItem = findLayerItem(container, childLayer.id);
+    expect(childLayerItem).toBeTruthy();
 
     await act(async () => {
         groupLayer.updateAttributes({
@@ -781,10 +781,10 @@ it("does not display layer item for child layer if the group's listMode is `hide
         }); //hide children of group layer in toc
         await nextTick();
     });
-    groupItemLabel = queryByLabelText(container, groupLayer.title, { selector: "label" });
-    expect(groupItemLabel).toBeTruthy(); //layer item for group should still be there
-    childItemLabel = queryByLabelText(container, childLayer.title, { selector: "label" });
-    expect(childItemLabel).toBeFalsy(); //layer item for child should no be there anymore
+    groupLayerItem = findLayerItem(container, groupLayer.id);
+    expect(groupLayerItem).toBeTruthy(); //layer item for group should still be there
+    childLayerItem = findLayerItem(container, childLayer.id);
+    expect(childLayerItem).toBeFalsy(); //layer item for child should no be there anymore
 });
 
 /** Returns the layer list's current list items. */

--- a/src/packages/toc/ui/LayerList/LayerList.test.tsx
+++ b/src/packages/toc/ui/LayerList/LayerList.test.tsx
@@ -709,7 +709,7 @@ it("displays the layer item only if the list mode is not `hide`", async () => {
         layer.setInternal(true); //make layer internal
         await nextTick();
     });
-    //layer item should still be there because toc specific listMode has precendences over internal attribute
+    //layer item should still be there because toc specific listMode has precedence over internal attribute
     layerItem = findLayerItem(container, layer.id);
     expect(layerItem).toBeTruthy();
 
@@ -783,7 +783,7 @@ it("does not display layer item for child layer if the group's listMode is `hide
     groupLayerItem = findLayerItem(container, groupLayer.id);
     expect(groupLayerItem).toBeTruthy(); //layer item for group should still be there
     childLayerItem = findLayerItem(container, childLayer.id);
-    expect(childLayerItem).toBeFalsy(); //layer item for child should no be there anymore
+    expect(childLayerItem).toBeFalsy(); //layer item for child should not be there anymore
 });
 
 /** Returns the layer list's current list items. */

--- a/src/packages/toc/ui/Toc.tsx
+++ b/src/packages/toc/ui/Toc.tsx
@@ -88,10 +88,22 @@ export interface ToolsConfig {
     showCollapseAllGroups?: boolean;
 }
 
+/**
+ * Layer attributes to specifically configure how a layer is displayed in the Toc
+ */
 export interface LayerItemAttributes {
-    listMode: ListMode;
+    /**
+     * The {@link ListMode} is used to hide the layer (or it's children) in the Toc.
+     */
+    listMode?: ListMode;
 }
 
+/**
+ * ListMode determines if a layer item is displayed in the Toc for the layer.
+ * The option `"hide-children"` provides a shortcut to hide all child layers (e.g sublayers of group) of the layer in the Toc. It has the same effect as manually setting the `listMode` to `"hide"` on all child layers.
+ *
+ * ListMode has precedence over the layer's `internal` attribute but specifically configures the layer's display in the Toc.
+ */
 export type ListMode = "show" | "hide" | "hide-children";
 
 const PADDING = 2;

--- a/src/packages/toc/ui/Toc.tsx
+++ b/src/packages/toc/ui/Toc.tsx
@@ -88,6 +88,12 @@ export interface ToolsConfig {
     showCollapseAllGroups?: boolean;
 }
 
+export interface LayerItemAttributes {
+    listMode: ListMode;
+}
+
+export type ListMode = "show" | "hide" | "hide-children";
+
 const PADDING = 2;
 
 /**

--- a/src/packages/toc/ui/Toc.tsx
+++ b/src/packages/toc/ui/Toc.tsx
@@ -89,9 +89,9 @@ export interface ToolsConfig {
 }
 
 /**
- * Layer attributes to specifically configure how a layer is displayed in the Toc
+ * Layer attributes to specifically configure how a layer is displayed in the Toc.
  */
-export interface LayerItemAttributes {
+export interface LayerTocAttributes {
     /**
      * The {@link ListMode} is used to hide the layer (or it's children) in the Toc.
      */
@@ -100,7 +100,8 @@ export interface LayerItemAttributes {
 
 /**
  * ListMode determines if a layer item is displayed in the Toc for the layer.
- * The option `"hide-children"` provides a shortcut to hide all child layers (e.g sublayers of group) of the layer in the Toc. It has the same effect as manually setting the `listMode` to `"hide"` on all child layers.
+ * The option `"hide-children"` provides a shortcut to hide all child layers (e.g. sublayers of group) of the layer in the Toc.
+ * It has the same effect as manually setting the `listMode` to `"hide"` on all child layers.
  *
  * ListMode has precedence over the layer's `internal` attribute but specifically configures the layer's display in the Toc.
  */

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -138,7 +138,9 @@ export function AppUI() {
                                             onClick={() => {
                                                 if (map) {
                                                     const layer =
-                                                        map.layers.getLayerById("street_network_wms");
+                                                        map.layers.getLayerById(
+                                                            "street_network_wms"
+                                                        );
                                                     if (layer) {
                                                         const listMode = (
                                                             layer.attributes.toc as
@@ -146,7 +148,9 @@ export function AppUI() {
                                                                 | undefined
                                                         )?.listMode;
                                                         const newListMode =
-                                                            listMode === "hide-children" ? "show" : "hide-children";
+                                                            listMode === "hide-children"
+                                                                ? "show"
+                                                                : "hide-children";
                                                         layer.updateAttributes({
                                                             toc: {
                                                                 listMode: newListMode

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Flex, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react";
 import { DefaultMapProvider, MapAnchor, MapContainer, useMapModel } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { SectionHeading, TitledSection } from "@open-pioneer/react-utils";
@@ -120,6 +120,21 @@ export function AppUI() {
                                             active={showToc}
                                             onClick={toggleToc}
                                         />
+                                        <Button onClick={() => {
+                                            if (map) {
+                                                const layer = map.layers.getLayerById("bustops");
+                                                if (layer) {
+                                                    const displayMode = layer.displayMode;
+                                                    if (displayMode === "show") {
+                                                        layer.setDisplayMode("hide");
+                                                    } else {
+                                                        layer.setDisplayMode("show");
+                                                    }
+                                                }
+                                            }
+                                        }}>
+                                           toggle display mode
+                                        </Button>
                                     </Flex>
                                 </MapAnchor>
                             </MapContainer>

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react";
 import { DefaultMapProvider, MapAnchor, MapContainer, useMapModel } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { SectionHeading, TitledSection } from "@open-pioneer/react-utils";
-import { LayerItemAttributes, Toc } from "@open-pioneer/toc";
+import { LayerTocAttributes, Toc } from "@open-pioneer/toc";
 import { useIntl } from "open-pioneer:react-hooks";
 import { useId, useState } from "react";
 import { PiListLight } from "react-icons/pi";
@@ -144,7 +144,7 @@ export function AppUI() {
                                                     if (layer) {
                                                         const listMode = (
                                                             layer.attributes.toc as
-                                                                | LayerItemAttributes
+                                                                | LayerTocAttributes
                                                                 | undefined
                                                         )?.listMode;
                                                         const newListMode =

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -126,12 +126,8 @@ export function AppUI() {
                                                     const layer =
                                                         map.layers.getLayerById("bustops");
                                                     if (layer) {
-                                                        const displayMode = layer.displayMode;
-                                                        if (displayMode === "show") {
-                                                            layer.setDisplayMode("hide");
-                                                        } else {
-                                                            layer.setDisplayMode("show");
-                                                        }
+                                                        const internal = layer.internal;
+                                                        layer.setInternal(!internal);
                                                     }
                                                 }
                                             }}

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -126,13 +126,27 @@ export function AppUI() {
                                                     const layer =
                                                         map.layers.getLayerById("bustops");
                                                     if (layer) {
+                                                        const isInternal = layer.internal;
+                                                        layer.setInternal(!isInternal);
+                                                    }
+                                                }
+                                            }}
+                                        >
+                                            toggle layer internal
+                                        </Button>
+                                        <Button
+                                            onClick={() => {
+                                                if (map) {
+                                                    const layer =
+                                                        map.layers.getLayerById("street_network_wms");
+                                                    if (layer) {
                                                         const listMode = (
                                                             layer.attributes.toc as
                                                                 | LayerItemAttributes
                                                                 | undefined
                                                         )?.listMode;
                                                         const newListMode =
-                                                            listMode === "hide" ? "show" : "hide";
+                                                            listMode === "hide-children" ? "show" : "hide-children";
                                                         layer.updateAttributes({
                                                             toc: {
                                                                 listMode: newListMode
@@ -142,7 +156,7 @@ export function AppUI() {
                                                 }
                                             }}
                                         >
-                                            toggle display mode
+                                            toggle toc list mode
                                         </Button>
                                     </Flex>
                                 </MapAnchor>

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -120,20 +120,23 @@ export function AppUI() {
                                             active={showToc}
                                             onClick={toggleToc}
                                         />
-                                        <Button onClick={() => {
-                                            if (map) {
-                                                const layer = map.layers.getLayerById("bustops");
-                                                if (layer) {
-                                                    const displayMode = layer.displayMode;
-                                                    if (displayMode === "show") {
-                                                        layer.setDisplayMode("hide");
-                                                    } else {
-                                                        layer.setDisplayMode("show");
+                                        <Button
+                                            onClick={() => {
+                                                if (map) {
+                                                    const layer =
+                                                        map.layers.getLayerById("bustops");
+                                                    if (layer) {
+                                                        const displayMode = layer.displayMode;
+                                                        if (displayMode === "show") {
+                                                            layer.setDisplayMode("hide");
+                                                        } else {
+                                                            layer.setDisplayMode("show");
+                                                        }
                                                     }
                                                 }
-                                            }
-                                        }}>
-                                           toggle display mode
+                                            }}
+                                        >
+                                            toggle display mode
                                         </Button>
                                     </Flex>
                                 </MapAnchor>

--- a/src/samples/test-toc/toc-app/AppUI.tsx
+++ b/src/samples/test-toc/toc-app/AppUI.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react";
 import { DefaultMapProvider, MapAnchor, MapContainer, useMapModel } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { SectionHeading, TitledSection } from "@open-pioneer/react-utils";
-import { Toc } from "@open-pioneer/toc";
+import { LayerItemAttributes, Toc } from "@open-pioneer/toc";
 import { useIntl } from "open-pioneer:react-hooks";
 import { useId, useState } from "react";
 import { PiListLight } from "react-icons/pi";
@@ -126,8 +126,18 @@ export function AppUI() {
                                                     const layer =
                                                         map.layers.getLayerById("bustops");
                                                     if (layer) {
-                                                        const internal = layer.internal;
-                                                        layer.setInternal(!internal);
+                                                        const listMode = (
+                                                            layer.attributes.toc as
+                                                                | LayerItemAttributes
+                                                                | undefined
+                                                        )?.listMode;
+                                                        const newListMode =
+                                                            listMode === "hide" ? "show" : "hide";
+                                                        layer.updateAttributes({
+                                                            toc: {
+                                                                listMode: newListMode
+                                                            }
+                                                        });
                                                     }
                                                 }
                                             }}

--- a/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
+++ b/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
@@ -8,6 +8,7 @@ import OSM from "ol/source/OSM";
 import VectorSource from "ol/source/Vector";
 import WMTS from "ol/source/WMTS";
 import WMTSTileGrid from "ol/tilegrid/WMTS";
+import { LayerTocAttributes } from "@open-pioneer/toc";
 
 export const MAP_ID = "main";
 
@@ -224,7 +225,7 @@ function createStrassenLayer() {
         attributes: {
             toc: {
                 listMode: "show"
-            }
+            } satisfies LayerTocAttributes
         },
         sublayers: [
             {

--- a/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
+++ b/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
@@ -94,7 +94,12 @@ export class MapConfigProviderImpl implements MapConfigProvider {
                                 "Haltestellen des öffentlichen Personenverkehrs in der Hanse- und Universitätsstadt Rostock.",
                             olLayer: createHaltestellenLayer(),
                             isBaseLayer: false,
-                            internal: true
+                            internal: false,
+                            attributes: {
+                                toc: {
+                                    listMode: "hide"
+                                }
+                            }
                         }),
                         createStrassenLayer()
                     ]
@@ -220,6 +225,11 @@ function createStrassenLayer() {
     return new WMSLayer({
         title: "Straßennetz Landesbetrieb Straßenbau NRW",
         url: "https://www.wms.nrw.de/wms/strassen_nrw_wms",
+        attributes: {
+            toc: {
+                listMode: "hide"
+            }
+        },
         sublayers: [
             {
                 name: "1",

--- a/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
+++ b/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
@@ -94,7 +94,7 @@ export class MapConfigProviderImpl implements MapConfigProvider {
                                 "Haltestellen des öffentlichen Personenverkehrs in der Hanse- und Universitätsstadt Rostock.",
                             olLayer: createHaltestellenLayer(),
                             isBaseLayer: false,
-                            displayMode: "hide"
+                            internal: true
                         }),
                         createStrassenLayer()
                     ]
@@ -231,8 +231,7 @@ function createStrassenLayer() {
             },
             {
                 name: "6",
-                title: "Unfälle",
-                displayMode: "hide"
+                title: "Unfälle"
             }
         ]
     });

--- a/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
+++ b/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
@@ -93,7 +93,8 @@ export class MapConfigProviderImpl implements MapConfigProvider {
                             description:
                                 "Haltestellen des öffentlichen Personenverkehrs in der Hanse- und Universitätsstadt Rostock.",
                             olLayer: createHaltestellenLayer(),
-                            isBaseLayer: false
+                            isBaseLayer: false,
+                            displayMode: "hide"
                         }),
                         createStrassenLayer()
                     ]
@@ -230,7 +231,8 @@ function createStrassenLayer() {
             },
             {
                 name: "6",
-                title: "Unfälle"
+                title: "Unfälle",
+                displayMode: "hide"
             }
         ]
     });

--- a/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
+++ b/src/samples/test-toc/toc-app/MapConfigProviderImpl.ts
@@ -94,12 +94,7 @@ export class MapConfigProviderImpl implements MapConfigProvider {
                                 "Haltestellen des öffentlichen Personenverkehrs in der Hanse- und Universitätsstadt Rostock.",
                             olLayer: createHaltestellenLayer(),
                             isBaseLayer: false,
-                            internal: false,
-                            attributes: {
-                                toc: {
-                                    listMode: "hide"
-                                }
-                            }
+                            internal: false
                         }),
                         createStrassenLayer()
                     ]
@@ -223,11 +218,12 @@ function createSchulenLayer() {
 
 function createStrassenLayer() {
     return new WMSLayer({
+        id: "street_network_wms",
         title: "Straßennetz Landesbetrieb Straßenbau NRW",
         url: "https://www.wms.nrw.de/wms/strassen_nrw_wms",
         attributes: {
             toc: {
-                listMode: "hide"
+                listMode: "show"
             }
         },
         sublayers: [


### PR DESCRIPTION
- introduce (reactive) property `displayMode` for any layer type (including sublayer)
  - `show`: layer item will be rendered in TOC (default, does not change current behavior)
  - `hide`: do not render layer item in TOC
  - `hide-children`: render layer item for (group) layer in TOC but do not render layer items for children
    - shortcut, same as hiding all child layers manually 
 - adjust TOC component to respect `displayMode`
   - reactive re-rendering if `displayMode` of a layer is changed at runtime
    
This PR is still a draft open for feedback and discussion.
See TOC sample app for preview.

ToDo:
- documentation
- (adjust) unit tests
- add changeset
- use `displayMode` for existing internal layers
  - currently implemented only for Measurement component
  - still missing:
    - editing
    - ? 