### PR TITLE
Extend license report to allow adding additional licenses 

### DIFF
--- a/support/license-config.yaml
+++ b/support/license-config.yaml
@@ -31,7 +31,6 @@ allowedLicenses:
 #      - custom: "./licenses/some-package-license.txt"
 #
 # `custom` makes the path relative to this directory instead of the package's directory.
-
 overrideLicenses:
   # 'license' missing in package.json but LICENSE file exists:
   - name: "react-universal-interface"
@@ -78,3 +77,39 @@ overrideLicenses:
   - name: "rgbcolor"
     version: "1.0.1"
     license: "MIT"
+
+# List of additional licenses that are used by the project but are not dependencies itself.
+# E.g. licenses of projects used by react-icons.
+# To specify licenses with a custom file that is not part of the original package,
+# configure the license like this:
+#
+#   - name: "some-package"
+#     version: "1.0.6"
+#     license: "MIT"
+#     licenseFiles:
+#      - custom: "./licenses/some-package-license.txt"
+#
+# `name`can be chosen freely, it does not have to match a package name.
+# `custom` makes the path relative to this directory instead of the package's directory and is required here.
+# `version`is optional.
+additionalLicenses:
+  # Lucide icons are used in the project and loaded by `react-icons`.
+  # License file retrieved on 2025-07-07 from https://github.com/lucide-icons/lucide/blob/main/LICENSE
+  - name: "Lucide"
+    license: "ISC"
+    licenseFiles:
+      - custom: "./licenses/lucide_isc"
+
+  # Feather icons are used in the project and loaded by `react-icons`.
+  # License file retrieved on 2025-07-07 from https://github.com/feathericons/feather/blob/main/LICENSE
+  - name: "Feather"
+    license: "MIT"
+    licenseFiles:
+      - custom: "./licenses/feather_mit"
+
+  # Tabler Icons is used in the project and loaded by `react-icons`.
+  # License file retrieved on 2025-07-07 from https://github.com/tabler/tabler-icons/blob/main/LICENSE
+  - name: "Tabler Icons"
+    license: "MIT"
+    licenseFiles:
+      - custom: "./licenses/tabler_icons_mit"

--- a/support/licenses/feather_mit
+++ b/support/licenses/feather_mit
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2023 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/support/licenses/lucide_isc
+++ b/support/licenses/lucide_isc
@@ -1,0 +1,15 @@
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/support/licenses/tabler_icons_mit
+++ b/support/licenses/tabler_icons_mit
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2024 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Extend license report to allow adding additional licenses and added licenses for react-icon libs in configuration. 