### PR TITLE
Remove map id from react components

### DIFF
--- a/.changeset/honest-bears-stick.md
+++ b/.changeset/honest-bears-stick.md
@@ -1,0 +1,32 @@
+---
+"@open-pioneer/map": minor
+---
+
+Add a new hook `useMapModelValue(props?)`.
+The hook returns either the directly configured `map` (via props) or the default map from a parent `DefaultMapProvider`.
+If neither is present, an error will be thrown.
+
+This hook is used in all components that work with the map.
+The typical usage works like this:
+
+```ts
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
+
+// optional `map` property inherited from `MapModelProps`
+export interface MyComponentProps extends MapModelProps {
+    // ... other properties
+}
+
+export function MyComponent(props) {
+    const map = useMapModelValue(props); // looks up the map
+}
+```
+
+You can also call this hook without any arguments:
+
+```ts
+// Map model from DefaultMapProvider or an error.
+const mapModel = useMapModelValue();
+```
+
+This hook should replace _most_ usages `useMapModel`, which can't return the map model directly since it may not have finished construction yet.

--- a/.changeset/thin-pets-trade.md
+++ b/.changeset/thin-pets-trade.md
@@ -1,0 +1,19 @@
+---
+"@open-pioneer/map": minor
+---
+
+Deprecate the parameter-less signature of `useMapModel()`:
+
+```ts
+// Returns the DefaultMapProvider's map, but wrapped in a result value (loading/resolved/rejected)
+const result = useMapModel();
+```
+
+Use `useMapModelValue()` instead:
+
+```ts
+// Returns the map model directly.
+const mapModel = useMapModelValue();
+```
+
+All other signatures of `useMapModel()` are still fully supported.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,6 +1068,9 @@ importers:
       '@chakra-ui/react':
         specifier: 'catalog:'
         version: 3.21.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@conterra/reactivity-core':
+        specifier: 'catalog:'
+        version: 0.7.0
       '@open-pioneer/map':
         specifier: workspace:^
         version: link:../map

--- a/src/packages/basemap-switcher/BasemapSwitcher.tsx
+++ b/src/packages/basemap-switcher/BasemapSwitcher.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, createListCollection, Portal, Select } from "@chakra-ui/react";
 import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
-import { Layer, useMapModel, MapModelProps, MapModel } from "@open-pioneer/map";
+import { Layer, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { useIntl } from "open-pioneer:react-hooks";
@@ -67,18 +67,12 @@ export interface BasemapSwitcherProps extends CommonComponentProps, MapModelProp
  * The `BasemapSwitcher` component can be used in an app to switch between the different basemaps.
  */
 export const BasemapSwitcher: FC<BasemapSwitcherProps> = (props) => {
-    const { map } = useMapModel(props);
-    return map && <BasemapSwitcherImpl {...props} map={map} />;
-};
-
-// Wait for the map resolve before rendering the component, this can be removed once we take the map model as a prop directly.
-function BasemapSwitcherImpl(props: BasemapSwitcherProps & { map: MapModel }) {
+    const map = useMapModelValue(props);
     const intl = useIntl();
     const {
         allowSelectingEmptyBasemap = false,
         "aria-label": ariaLabel,
-        "aria-labelledby": ariaLabelledBy,
-        map
+        "aria-labelledby": ariaLabelledBy
     } = props;
     const { containerProps } = useCommonComponentProps("basemap-switcher", props);
     const emptyBasemapLabel = intl.formatMessage({ id: "emptyBasemapLabel" });
@@ -149,7 +143,7 @@ function BasemapSwitcherImpl(props: BasemapSwitcherProps & { map: MapModel }) {
             </Select.Root>
         </Box>
     );
-}
+};
 
 function BasemapItem(props: { item: SelectOption }) {
     const intl = useIntl();

--- a/src/packages/coordinate-search/CoordinateInput.tsx
+++ b/src/packages/coordinate-search/CoordinateInput.tsx
@@ -3,7 +3,7 @@
 import { Flex, Group } from "@chakra-ui/react";
 import { computed, Reactive, reactive } from "@conterra/reactivity-core";
 import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps, useEvent } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { NumberParserService, PackageIntl } from "@open-pioneer/runtime";
@@ -132,9 +132,9 @@ export const CoordinateInput: FC<CoordinateInputProps> = (props) => {
         placeholder = ""
     } = props;
     const { containerProps } = useCommonComponentProps("coordinate-input", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
-    const mapProjection = useReactiveSnapshot(() => map?.projection, [map]);
+    const mapProjection = useReactiveSnapshot(() => map.projection, [map]);
 
     // Projection items (dropdown)
     const availableProjections = useProjectionItems(projections);

--- a/src/packages/coordinate-search/CoordinateSearch.tsx
+++ b/src/packages/coordinate-search/CoordinateSearch.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
-import { FC, useEffect, useState } from "react";
 import { Coordinate } from "ol/coordinate";
 import { EventsKey } from "ol/events";
-import { unByKey } from "ol/Observable";
 import OlMap from "ol/Map";
+import { unByKey } from "ol/Observable";
+import { FC, useEffect, useState } from "react";
 import { CoordinateInput, CoordinatesSelectEvent, ProjectionInput } from "./CoordinateInput";
 
 /**
@@ -36,29 +36,23 @@ export interface CoordinateSearchProps extends CommonComponentProps, MapModelPro
 export const CoordinateSearch: FC<CoordinateSearchProps> = (props) => {
     const { onSelect, onClear, projections } = props;
     const { containerProps } = useCommonComponentProps("coordinate-search", props);
-    const { map } = useMapModel(props);
-    const olMap = map?.olMap;
+    const map = useMapModelValue(props);
+    const olMap = map.olMap;
 
     const { coordinates } = useCoordinates(olMap); // coordinates of the pointer in the map
 
     return (
-        map && (
-            <CoordinateInput
-                {...containerProps}
-                map={map}
-                onSelect={(event: CoordinatesSelectEvent) => {
-                    if (!map) {
-                        return;
-                    }
-
-                    olMap?.getView().setCenter(event.coords);
-                    onSelect?.(event);
-                }}
-                onClear={onClear}
-                placeholder={coordinates ? coordinates : ""}
-                projections={projections}
-            />
-        )
+        <CoordinateInput
+            {...containerProps}
+            map={map}
+            onSelect={(event: CoordinatesSelectEvent) => {
+                olMap.getView().setCenter(event.coords);
+                onSelect?.(event);
+            }}
+            onClear={onClear}
+            placeholder={coordinates ? coordinates : ""}
+            projections={projections}
+        />
     );
 };
 

--- a/src/packages/coordinate-viewer/CoordinateViewer.tsx
+++ b/src/packages/coordinate-viewer/CoordinateViewer.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { PackageIntl } from "@open-pioneer/runtime";
@@ -46,12 +46,11 @@ export interface CoordinateViewerProps extends CommonComponentProps, MapModelPro
 export const CoordinateViewer: FC<CoordinateViewerProps> = (props) => {
     const { precision, displayProjectionCode, format } = props;
     const { containerProps } = useCommonComponentProps("coordinate-viewer", props);
-    const { map } = useMapModel(props);
-    const olMap = map?.olMap;
+    const map = useMapModelValue(props);
     const mapProjectionCode = useReactiveSnapshot(() => {
         return map?.projection.getCode() ?? "";
     }, [map]);
-    let { coordinates } = useCoordinates(olMap);
+    let { coordinates } = useCoordinates(map.olMap);
     coordinates =
         coordinates && displayProjectionCode
             ? transformCoordinates(coordinates, mapProjectionCode, displayProjectionCode)
@@ -79,18 +78,13 @@ export function useCoordinatesString(
     return coordinatesString;
 }
 
-function useCoordinates(map: OlMap | undefined): { coordinates: Coordinate | undefined } {
+function useCoordinates(map: OlMap): { coordinates: Coordinate | undefined } {
     const [coordinates, setCoordinates] = useState<Coordinate | undefined>();
 
     useEffect(() => {
-        if (!map) {
-            return;
-        }
-
         const eventsKey: EventsKey = map.on("pointermove", (evt) => {
             setCoordinates(evt.coordinate);
         });
-
         return () => unByKey(eventsKey);
     }, [map]);
 

--- a/src/packages/geolocation/Geolocation.tsx
+++ b/src/packages/geolocation/Geolocation.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { ButtonProps } from "@chakra-ui/react";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { NotificationService } from "@open-pioneer/notifier";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
@@ -48,7 +48,7 @@ export interface GeolocationProps
 
 export const Geolocation: FC<GeolocationProps> = function Geolocation(props: GeolocationProps) {
     const { maxZoom, positionFeatureStyle, accuracyFeatureStyle, trackingOptions, ref } = props;
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const controller = useController(
         map,
         maxZoom,
@@ -110,7 +110,7 @@ const GeolocationImpl = function GeolocationImpl(
 };
 
 function useController(
-    map: MapModel | undefined,
+    map: MapModel,
     maxZoom: number | undefined,
     trackingOptions: PositionOptions | undefined,
     positionFeatureStyle: StyleLike | undefined,
@@ -120,10 +120,6 @@ function useController(
     const notificationService = useService<NotificationService>("notifier.NotificationService");
     const [controller, setController] = useState<GeolocationController>();
     useEffect(() => {
-        if (!map) {
-            return;
-        }
-
         const onError: OnErrorCallback = (error) => {
             const title = intl.formatMessage({ id: "error" });
             const description = (() => {

--- a/src/packages/legend/Legend.tsx
+++ b/src/packages/legend/Legend.tsx
@@ -1,13 +1,20 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { LuTriangleAlert } from "react-icons/lu";
-import { Box, Image, List, Text, Icon } from "@chakra-ui/react";
-import { Layer, AnyLayer, MapModel, useMapModel, MapModelProps, isLayer } from "@open-pioneer/map";
+import { Box, Icon, Image, List, Text } from "@chakra-ui/react";
+import {
+    AnyLayer,
+    Layer,
+    MapModel,
+    MapModelProps,
+    isLayer,
+    useMapModelValue
+} from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import classNames from "classnames";
 import { useIntl } from "open-pioneer:react-hooks";
 import { ComponentType, FC, ReactNode, useEffect, useMemo, useState } from "react";
+import { LuTriangleAlert } from "react-icons/lu";
 
 /**
  * Properties of a legend item React component.
@@ -56,11 +63,11 @@ export interface LegendProps extends CommonComponentProps, MapModelProps {
 export const Legend: FC<LegendProps> = (props) => {
     const { showBaseLayers = false } = props;
     const { containerProps } = useCommonComponentProps("legend", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
 
     return (
         <Box {...containerProps}>
-            {map ? <LegendList map={map} showBaseLayers={showBaseLayers} /> : null}
+            <LegendList map={map} showBaseLayers={showBaseLayers} />
         </Box>
     );
 };

--- a/src/packages/map-navigation/History.test.tsx
+++ b/src/packages/map-navigation/History.test.tsx
@@ -1,23 +1,22 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-
 import { createServiceOptions, setupMap } from "@open-pioneer/map-test-utils";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, it } from "vitest";
 import { HistoryBackward, HistoryForward } from "./History";
+import { ReactNode } from "react";
 
 it("should successfully create an view history navigation component", async () => {
-    const { mapId, registry } = await setupMap();
-    const map = await registry.expectMapModel(mapId);
-    const services = createServiceOptions({ registry });
+    const { map, Wrapper } = await setup();
 
     render(
-        <PackageContextProvider services={services}>
+        <>
             <HistoryBackward map={map} data-testid="navi-history-back" />
             <HistoryForward map={map} data-testid="navi-history-for" />
-        </PackageContextProvider>
+        </>,
+        { wrapper: Wrapper }
     );
 
     const { historyDivForward, historyDivBackward } = await waitForHistoryComponent();
@@ -31,15 +30,14 @@ it("should successfully create an view history navigation component", async () =
 
 it("should successfully disable/enable buttons", async () => {
     const user = userEvent.setup();
-    const { mapId, registry } = await setupMap();
-    const map = await registry.expectMapModel(mapId);
-    const services = createServiceOptions({ registry });
+    const { map, Wrapper } = await setup();
 
     render(
-        <PackageContextProvider services={services}>
+        <>
             <HistoryBackward map={map} data-testid="navi-history-back" />
             <HistoryForward map={map} data-testid="navi-history-for" />
-        </PackageContextProvider>
+        </>,
+        { wrapper: Wrapper }
     );
 
     // Wait for mount to ensure view model is present and listening
@@ -93,15 +91,14 @@ it("should successfully disable/enable buttons", async () => {
 
 it("should successfully change the map view on forward", async () => {
     const user = userEvent.setup();
-    const { mapId, registry } = await setupMap();
-    const map = await registry.expectMapModel(mapId);
-    const services = createServiceOptions({ registry });
+    const { map, Wrapper } = await setup();
 
     render(
-        <PackageContextProvider services={services}>
+        <>
             <HistoryBackward map={map} data-testid="navi-history-back" />
             <HistoryForward map={map} data-testid="navi-history-for" />
-        </PackageContextProvider>
+        </>,
+        { wrapper: Wrapper }
     );
 
     const { historyDivForward, historyDivBackward } = await waitForHistoryComponent();
@@ -143,15 +140,16 @@ it("should successfully change the map view on forward", async () => {
 
 it("should successfully change the map view on backward", async () => {
     const user = userEvent.setup();
-    const { mapId, registry } = await setupMap();
-    const map = await registry.expectMapModel(mapId);
-    const services = createServiceOptions({ registry });
+    const { map, Wrapper } = await setup();
 
     render(
-        <PackageContextProvider services={services}>
+        <>
             <HistoryBackward map={map} data-testid="navi-history-back" />
             <HistoryForward map={map} data-testid="navi-history-for" />
-        </PackageContextProvider>
+        </>,
+        {
+            wrapper: Wrapper
+        }
     );
 
     const { historyDivBackward } = await waitForHistoryComponent();
@@ -197,4 +195,15 @@ async function waitForHistoryComponent() {
     )) as HTMLButtonElement;
 
     return { historyDivForward, historyDivBackward };
+}
+
+async function setup() {
+    const { map, registry } = await setupMap();
+    const services = createServiceOptions({ registry });
+
+    function Wrapper(props: { children?: ReactNode }) {
+        return <PackageContextProvider services={services} {...props} />;
+    }
+
+    return { map, Wrapper };
 }

--- a/src/packages/map-navigation/History.tsx
+++ b/src/packages/map-navigation/History.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { ButtonProps } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
@@ -63,7 +63,7 @@ export interface HistoryProps
 export const History: FC<HistoryProps> = function History(props: HistoryProps) {
     const intl = useIntl();
     const { buttonProps, viewDirection, ref } = props;
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const viewModel = useHistoryViewModel(map);
     const { defaultClassName, buttonLabel, buttonIcon } = getDirectionProps(intl, viewDirection);
     const { containerProps } = useCommonComponentProps(classNames("view", defaultClassName), props);

--- a/src/packages/map-navigation/InitialExtent.tsx
+++ b/src/packages/map-navigation/InitialExtent.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { ButtonProps } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { Extent } from "ol/extent";
@@ -28,12 +28,12 @@ export const InitialExtent: FC<InitialExtentProps> = function InitialExtent(
     props: InitialExtentProps
 ) {
     const { containerProps } = useCommonComponentProps("initial-extent", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
     const { buttonProps, ref } = props;
 
     function setInitExtent() {
-        const initialExtent = map?.initialExtent;
+        const initialExtent = map.initialExtent;
         if (initialExtent) {
             const newExtent: Extent = [
                 initialExtent.xMin,

--- a/src/packages/map-navigation/ViewHistoryModel.ts
+++ b/src/packages/map-navigation/ViewHistoryModel.ts
@@ -145,13 +145,9 @@ const VIEW_MODELS = new WeakMap<MapModel, ViewModelState>();
  *
  * NOTE: May be useful to have this a general solution in the future; but this is the only usage right now.
  */
-export function useHistoryViewModel(map: MapModel | undefined): ViewHistoryModel | undefined {
+export function useHistoryViewModel(map: MapModel): ViewHistoryModel | undefined {
     const [vm, setVm] = useState<ViewHistoryModel>();
     useEffect(() => {
-        if (!map) {
-            return;
-        }
-
         let state = VIEW_MODELS.get(map);
         if (state == null) {
             state = {

--- a/src/packages/map-navigation/Zoom.tsx
+++ b/src/packages/map-navigation/Zoom.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { ButtonProps } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { ToolButton } from "@open-pioneer/map-ui-components";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { PackageIntl } from "@open-pioneer/runtime";
@@ -56,7 +56,7 @@ export interface ZoomProps
  */
 export const Zoom: FC<ZoomProps> = function Zoom(props: ZoomProps) {
     const { buttonProps, zoomDirection, ref } = props;
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
     const [disabled, setDisabled] = useState<boolean>(false);
     const { defaultClassName, buttonLabel, buttonIcon } = getDirectionProps(intl, zoomDirection);
@@ -68,12 +68,13 @@ export const Zoom: FC<ZoomProps> = function Zoom(props: ZoomProps) {
             return;
         }
         setDisabled(true);
-        const view = map?.olView;
-        let currZoom = map?.zoomLevel;
 
-        const maxZoom = view?.getMaxZoom() || Number.MAX_SAFE_INTEGER;
-        const minZoom = view?.getMinZoom() || 0;
-        if (view && currZoom !== undefined) {
+        const view = map.olView;
+        const maxZoom = view.getMaxZoom() || Number.MAX_SAFE_INTEGER;
+        const minZoom = view.getMinZoom() || 0;
+
+        let currZoom = map.zoomLevel;
+        if (currZoom != null) {
             if (zoomDirection === "in" && currZoom < maxZoom) {
                 ++currZoom;
             } else if (zoomDirection === "out" && currZoom > minZoom) {

--- a/src/packages/map-test-utils/index.ts
+++ b/src/packages/map-test-utils/index.ts
@@ -19,6 +19,8 @@ import { createService } from "@open-pioneer/test-utils/services";
 import { screen, waitFor } from "@testing-library/react";
 import VectorLayer from "ol/layer/Vector";
 
+export type LayerConfig = SimpleLayerConfig | Layer;
+
 export interface SimpleMapOptions {
     /** ID of the map.
      * Defaults to "test". */
@@ -43,7 +45,7 @@ export interface SimpleMapOptions {
     /**
      * Layers used by the map.
      */
-    layers?: (SimpleLayerConfig | Layer)[];
+    layers?: LayerConfig[];
 
     /**
      * Overrides fetching of network resources (such as service capabilities).

--- a/src/packages/map/README.md
+++ b/src/packages/map/README.md
@@ -280,9 +280,9 @@ Based on the example above, you can set different properties using the layer API
 Example: How to set different properties.
 
 ```js
-import { useMapModel } from "@open-pioneer/map";
+import { useMapModelValue } from "@open-pioneer/map";
 
-const { map } = useMapModel(mapId);
+const map = useMapModelValue();
 const layer = map.layers.getLayerById("abe0e3f8-0ba2-409c-b6b4-9d8429c732e3");
 
 layer.setDescription("new description");
@@ -726,7 +726,7 @@ The most important API items are as follows:
 - The `MapRegistry` service (inject via `"map.MapRegistry"`).
   This service is used to obtain a reference to the `MapModel` via `registry.getMapModel(mapId)`.
 
-    > NOTE: From inside a React component you can also use the hook `useMapModel(mapId)` (or `useMapModel()` if using the DefaultMapProvider).
+    > NOTE: From inside a React component you can also use the hook `useMapModel(mapId)` (or `useMapModelValue()` if using the DefaultMapProvider).
 
 - The `MapModel` represents a map in an application.
   Through the `MapModel` one can obtain the map's base layers, operational layers and so on.
@@ -869,27 +869,39 @@ export class TestService {
 
 #### Using the map model in React components
 
-To access the map model instance, use the React hook `useMapModel`.
+To access the map model instance, use the React hooks `useMapModel` or `useMapModelValue`.
 
-Example: Center map to given coordinates using the map model.
+- `useMapModelValue` returns the map model specified by a `DefaultMapProvider` parent.
+  This is a convenient API to avoid passing the map model as a prop everywhere:
 
-```js
-import { useMapModel } from "@open-pioneer/map";
-import { MAP_ID } from "./MapConfigProviderImpl";
+    ```tsx
+    function YourComponent() {
+        const map = useMapModelValue(); // requires a <DefaultMapProvider /> parent somewhere in the React tree
+    }
+    ```
 
-export function AppUI() {
-    // mapState.map may be undefined initially, if the map is still configuring.
-    // the object may may also be in an "error" state.
-    const mapState = useMapModel(MAP_ID);
+- `useMapModel` takes a `mapId` and returns a result.
+  The result will ultimately resolve to either a map model or an error (if initialization of the map failed).
 
-    const centerBerlin = () => {
-        const olMap = mapState.map?.olMap;
-        if (olMap) {
-            olMap?.getView().fit([1489200, 6894026, 1489200, 6894026], { maxZoom: 13 });
-        }
-    };
-}
-```
+    Example: Center map to given coordinates using the map model.
+
+    ```js
+    import { useMapModel } from "@open-pioneer/map";
+    import { MAP_ID } from "./MapConfigProviderImpl";
+
+    export function AppUI() {
+        // mapState.map may be undefined initially, if the map is still configuring.
+        // the object may may also be in an "error" state.
+        const mapState = useMapModel(MAP_ID);
+
+        const centerBerlin = () => {
+            const olMap = mapState.map?.olMap;
+            if (olMap) {
+                olMap?.getView().fit([1489200, 6894026, 1489200, 6894026], { maxZoom: 13 });
+            }
+        };
+    }
+    ```
 
 ## License
 

--- a/src/packages/map/api/index.ts
+++ b/src/packages/map/api/index.ts
@@ -14,6 +14,7 @@ export { MapAnchor, type MapAnchorProps, type MapAnchorPosition } from "../ui/Ma
 export { MapContainer, type MapContainerProps } from "../ui/MapContainer";
 export {
     useMapModel,
+    useMapModelValue,
     type UseMapModelResult,
     type UseMapModelLoading,
     type UseMapModelResolved,

--- a/src/packages/map/ui/DefaultMapProvider.tsx
+++ b/src/packages/map/ui/DefaultMapProvider.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { createContext, useContext, useMemo } from "react";
+import { createContext, useContext } from "react";
+import { MapModel } from "../api";
 import { MapModelProps } from "./useMapModel";
 
-const DefaultMapContext = createContext<MapModelProps | undefined>(undefined);
+const DefaultMapContext = createContext<MapModel | undefined>(undefined);
 DefaultMapContext.displayName = "DefaultMapContext";
 
 /**
@@ -21,18 +22,14 @@ DefaultMapContext.displayName = "DefaultMapContext";
  * </DefaultMapProvider>
  * ```
  */
-export function DefaultMapProvider(props: MapModelProps & { children?: React.ReactNode }) {
-    const { mapId, map, children } = props;
-    const value = useMemo((): MapModelProps => ({ mapId, map }), [mapId, map]);
-    if (mapId != null && map != null) {
-        throw new Error(
-            `Cannot specify both 'mapId' and 'map' in DefaultMapProvider at the same time.`
-        );
+export function DefaultMapProvider(
+    props: Required<MapModelProps> & { children?: React.ReactNode }
+) {
+    const { map, children } = props;
+    if (map == null) {
+        throw new Error(`DefaultMapProvider requires the 'map' property.`);
     }
-    if (mapId == null && map == null) {
-        throw new Error(`Either 'mapId' or 'map' must be specified in DefaultMapProvider.`);
-    }
-    return <DefaultMapContext.Provider value={value}>{children}</DefaultMapContext.Provider>;
+    return <DefaultMapContext.Provider value={map}>{children}</DefaultMapContext.Provider>;
 }
 
 /**
@@ -40,6 +37,6 @@ export function DefaultMapProvider(props: MapModelProps & { children?: React.Rea
  *
  * @internal
  */
-export function useDefaultMapProps(): MapModelProps | undefined {
+export function useDefaultMap(): MapModel | undefined {
     return useContext(DefaultMapContext);
 }

--- a/src/packages/map/ui/MapContainer.tsx
+++ b/src/packages/map/ui/MapContainer.tsx
@@ -8,7 +8,7 @@ import { Extent } from "ol/extent";
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { MapModel, MapPadding } from "../api";
 import { MapContainerContextProvider, MapContainerContextType } from "./MapContainerContext";
-import { MapModelProps, useMapModel } from "./useMapModel";
+import { MapModelProps, useMapModelValue } from "./useMapModel";
 const LOG = createLogger("map:MapContainer");
 
 export interface MapContainerProps extends CommonComponentProps, MapModelProps {
@@ -74,32 +74,17 @@ export function MapContainer(props: MapContainerProps) {
     const { containerProps } = useCommonComponentProps("map-container-root", props);
     const mapContainer = useRef<HTMLDivElement>(null);
     const mapAnchorsHost = useRef<HTMLDivElement>(null);
-    const modelState = useMapModel(props);
-    const map = modelState.map;
+    const map = useMapModelValue(props);
 
     const [ready, setReady] = useState(false);
 
     useEffect(() => {
-        if (modelState.kind === "loading") {
-            return;
-        }
-
-        if (modelState.kind === "rejected") {
-            LOG.error(`Cannot display the map. Caused by `, modelState.error);
-            return;
-        }
-
-        if (!map) {
-            LOG.error(`No configuration available for the configured map.`);
-            return;
-        }
-
         // Mount the map into the DOM
         if (mapContainer.current) {
             const resource = registerMapTarget(map, mapContainer.current);
             return () => resource?.destroy();
         }
-    }, [modelState, map]);
+    }, [map]);
 
     // Wait for mount to make sure that the map anchors host is available
     useEffect(() => {

--- a/src/packages/map/ui/useMapModel.test.tsx
+++ b/src/packages/map/ui/useMapModel.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MapModel, MapRegistry } from "../api";
-import { useMapModel, UseMapModelResult } from "./useMapModel";
+import { useMapModel, UseMapModelResult, useMapModelValue } from "./useMapModel";
 import { DefaultMapProvider } from "./DefaultMapProvider";
 import { renderHook, RenderHookResult, waitFor } from "@testing-library/react";
 import {
@@ -16,170 +16,169 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-it("returns the immediately configured map model if specified", async () => {
-    const services = mockServices();
-    const mapModel = mockMapModel();
-    const hook = renderHook(() => useMapModel({ map: mapModel }), {
-        wrapper: (props) => <PackageContextProvider services={services} {...props} />
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBe(mapModel);
-});
-
-it("resolves the map model from the registry if mapId is specified", async () => {
-    const services = mockServices({ expectedMapId: "foo" });
-    const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
-        wrapper: (props) => <PackageContextProvider services={services} {...props} />
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBeDefined();
-});
-
-it("resolves the map model from the registry if mapId is specified (old overload)", async () => {
-    const services = mockServices({ expectedMapId: "foo" });
-    const hook = renderHook(() => useMapModel("foo"), {
-        wrapper: (props) => <PackageContextProvider services={services} {...props} />
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBeDefined();
-});
-
-it("supports default map model from context", async () => {
-    const services = mockServices();
-    const mapModel = mockMapModel();
-    const hook = renderHook(() => useMapModel({}), {
-        wrapper: (props) => (
-            <PackageContextProvider services={services}>
-                <DefaultMapProvider map={mapModel}>{props.children}</DefaultMapProvider>
-            </PackageContextProvider>
-        )
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBe(mapModel);
-});
-
-it("supports default map id from context", async () => {
-    const services = mockServices({ expectedMapId: "foo" });
-    const hook = renderHook(() => useMapModel({}), {
-        wrapper: (props) => (
-            <PackageContextProvider services={services}>
-                <DefaultMapProvider mapId="foo">{props.children}</DefaultMapProvider>
-            </PackageContextProvider>
-        )
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBeDefined();
-});
-
-it("local configuration of map model takes precedence", async () => {
-    const services = mockServices();
-    const mapModel = mockMapModel();
-    const otherMapModel = mockMapModel();
-    const hook = renderHook(() => useMapModel({ map: mapModel }), {
-        wrapper: (props) => (
-            <PackageContextProvider services={services}>
-                <DefaultMapProvider map={otherMapModel}>{props.children}</DefaultMapProvider>
-            </PackageContextProvider>
-        )
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBe(mapModel);
-});
-
-it("local configuration of map id takes precedence", async () => {
-    const services = mockServices({ expectedMapId: "foo" });
-    const otherMapModel = mockMapModel();
-    const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
-        wrapper: (props) => (
-            <PackageContextProvider services={services}>
-                <DefaultMapProvider map={otherMapModel}>{props.children}</DefaultMapProvider>
-            </PackageContextProvider>
-        )
-    });
-    const result = await waitForMapModel(hook);
-    expect(result).toBeDefined();
-    expect(result).not.toBe(otherMapModel);
-});
-
-it("throws an error if neither local nor default configuration is available", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined); // react also logs this error
-    expect(() => {
-        const services = mockServices();
-        renderHook(() => useMapModel({}), {
+describe("useMapModel", () => {
+    it("resolves the map model from the registry if mapId is specified", async () => {
+        const services = mockServices({ expectedMapId: "foo" });
+        const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
             wrapper: (props) => <PackageContextProvider services={services} {...props} />
         });
-    }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: No map specified. You must either specify the map (or its id) via a DefaultMapProvider parent or configure it explicitly.]`
-    );
-});
+        const result = await waitForMapModel(hook);
+        expect(result).toBeDefined();
+    });
 
-it("throws an error if the map model is passed directly", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined); // react also logs this error
+    it("resolves the map model from the registry if mapId is specified (string overload)", async () => {
+        const services = mockServices({ expectedMapId: "foo" });
+        const hook = renderHook(() => useMapModel("foo"), {
+            wrapper: (props) => <PackageContextProvider services={services} {...props} />
+        });
+        const result = await waitForMapModel(hook);
+        expect(result).toBeDefined();
+    });
 
-    const services = mockServices();
-    const mapModel = mockMapModel();
-    const otherMapModel = mockMapModel();
-    expect(() => {
-        renderHook(() => useMapModel(mapModel as any), {
+    it("supports default map model from context", async () => {
+        const services = mockServices();
+        const mapModel = mockMapModel();
+
+        const hook = renderHook(() => useMapModel(), {
             wrapper: (props) => (
                 <PackageContextProvider services={services}>
-                    <DefaultMapProvider map={otherMapModel}>{props.children}</DefaultMapProvider>
+                    <DefaultMapProvider map={mapModel}>{props.children}</DefaultMapProvider>
                 </PackageContextProvider>
             )
         });
-    }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Map model instances cannot be passed directly to 'useMapModel' (see TypeScript signature).]`
-    );
+        const result = await waitForMapModel(hook);
+        expect(result).toBe(mapModel);
+    });
+
+    it("throws an error if neither local nor default configuration is available", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => undefined); // react also logs this error
+        expect(() => {
+            const services = mockServices();
+            renderHook(() => useMapModel(), {
+                wrapper: (props) => <PackageContextProvider services={services} {...props} />
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `[Error: No map specified. Either configure a mapId or use the DefaultMapProvider.]`
+        );
+    });
+
+    it("throws an error if the map model is passed directly", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => undefined); // react also logs this error
+
+        const services = mockServices();
+        const mapModel = mockMapModel();
+        const otherMapModel = mockMapModel();
+        expect(() => {
+            renderHook(() => useMapModel(mapModel as any), {
+                wrapper: (props) => (
+                    <PackageContextProvider services={services}>
+                        <DefaultMapProvider map={otherMapModel}>
+                            {props.children}
+                        </DefaultMapProvider>
+                    </PackageContextProvider>
+                )
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `[Error: Map model instances cannot be passed directly to 'useMapModel' (see TypeScript signature).]`
+        );
+    });
+
+    it("returns the async loading status of the map model", async () => {
+        const mapModel = mockMapModel();
+        const { promise, resolve } = createManualPromise<MapModel>();
+
+        const services = mockServices({ expectedMapId: "foo", customPromise: promise });
+        const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
+            wrapper: (props) => <PackageContextProvider services={services} {...props} />
+        });
+
+        expect(hook.result.current.kind).toBe("loading");
+        expect(hook.result.current.map).toBeUndefined();
+        expect(hook.result.current.error).toBeUndefined();
+
+        resolve(mapModel);
+        await waitFor(() => {
+            if (hook.result.current.kind === "loading") {
+                throw new Error("still loading");
+            }
+        });
+
+        expect(hook.result.current.kind).toBe("resolved");
+        expect(hook.result.current.map).toBe(mapModel);
+        expect(hook.result.current.error).toBeUndefined();
+    });
+
+    it("returns the async loading error of the map model", async () => {
+        const { promise, reject } = createManualPromise<MapModel>();
+
+        const services = mockServices({ expectedMapId: "foo", customPromise: promise });
+        const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
+            wrapper: (props) => <PackageContextProvider services={services} {...props} />
+        });
+
+        expect(hook.result.current.kind).toBe("loading");
+        expect(hook.result.current.map).toBeUndefined();
+        expect(hook.result.current.error).toBeUndefined();
+
+        const err = new Error("some error");
+        reject(err);
+        await waitFor(() => {
+            if (hook.result.current.kind === "loading") {
+                throw new Error("still loading");
+            }
+        });
+
+        expect(hook.result.current.kind).toBe("rejected");
+        expect(hook.result.current.map).toBe(undefined);
+        expect(hook.result.current.error).toBe(err);
+    });
 });
 
-it("returns the async loading status of the map model", async () => {
-    const mapModel = mockMapModel();
-    const { promise, resolve } = createManualPromise<MapModel>();
-
-    const services = mockServices({ expectedMapId: "foo", customPromise: promise });
-    const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
-        wrapper: (props) => <PackageContextProvider services={services} {...props} />
+describe("useMapModelValue", () => {
+    it("local configuration of map model takes precedence", async () => {
+        const services = mockServices();
+        const directMapModel = mockMapModel();
+        const defaultMapModel = mockMapModel();
+        const hook = renderHook(() => useMapModelValue({ map: directMapModel }), {
+            wrapper: (props) => (
+                <PackageContextProvider services={services}>
+                    <DefaultMapProvider map={defaultMapModel}>{props.children}</DefaultMapProvider>
+                </PackageContextProvider>
+            )
+        });
+        const result = hook.result.current;
+        expect(result).toBe(directMapModel);
     });
 
-    expect(hook.result.current.kind).toBe("loading");
-    expect(hook.result.current.map).toBeUndefined();
-    expect(hook.result.current.error).toBeUndefined();
-
-    resolve(mapModel);
-    await waitFor(() => {
-        if (hook.result.current.kind === "loading") {
-            throw new Error("still loading");
-        }
+    it("returns default map model if no local map model has been configured", async () => {
+        const services = mockServices();
+        const defaultMapModel = mockMapModel();
+        const hook = renderHook(() => useMapModelValue({}), {
+            wrapper: (props) => (
+                <PackageContextProvider services={services}>
+                    <DefaultMapProvider map={defaultMapModel}>{props.children}</DefaultMapProvider>
+                </PackageContextProvider>
+            )
+        });
+        const result = hook.result.current;
+        expect(result).toBe(defaultMapModel);
     });
 
-    expect(hook.result.current.kind).toBe("resolved");
-    expect(hook.result.current.map).toBe(mapModel);
-    expect(hook.result.current.error).toBeUndefined();
-});
+    it("throws if neither has been configured", async () => {
+        const services = mockServices();
 
-it("returns the async loading error of the map model", async () => {
-    const { promise, reject } = createManualPromise<MapModel>();
-
-    const services = mockServices({ expectedMapId: "foo", customPromise: promise });
-    const hook = renderHook(() => useMapModel({ mapId: "foo" }), {
-        wrapper: (props) => <PackageContextProvider services={services} {...props} />
+        expect(() =>
+            renderHook(() => useMapModelValue({}), {
+                wrapper: (props) => (
+                    <PackageContextProvider services={services}>
+                        {props.children}
+                    </PackageContextProvider>
+                )
+            })
+        ).toThrowErrorMatchingInlineSnapshot(
+            `[Error: No map specified. You must either specify the map via a DefaultMapProvider parent or configure it explicitly.]`
+        );
     });
-
-    expect(hook.result.current.kind).toBe("loading");
-    expect(hook.result.current.map).toBeUndefined();
-    expect(hook.result.current.error).toBeUndefined();
-
-    const err = new Error("some error");
-    reject(err);
-    await waitFor(() => {
-        if (hook.result.current.kind === "loading") {
-            throw new Error("still loading");
-        }
-    });
-
-    expect(hook.result.current.kind).toBe("rejected");
-    expect(hook.result.current.map).toBe(undefined);
-    expect(hook.result.current.error).toBe(err);
 });
 
 async function waitForMapModel(

--- a/src/packages/measurement/Measurement.tsx
+++ b/src/packages/measurement/Measurement.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Button, Field, HStack, Text } from "@chakra-ui/react";
 import { NativeSelectField, NativeSelectRoot } from "@open-pioneer/chakra-snippets/native-select";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { PackageIntl } from "@open-pioneer/runtime";
 import LineString from "ol/geom/LineString";
@@ -70,8 +70,8 @@ export const Measurement: FC<MeasurementProps> = (props) => {
     const { containerProps } = useCommonComponentProps("measurement", props);
     const [selectedMeasurement, setMeasurement] = useState<MeasurementType>("distance");
     const label = (id: string) => intl.formatMessage({ id: id });
-    const mapState = useMapModel(props);
-    const controller = useController(mapState.map, props, intl);
+    const map = useMapModelValue(props);
+    const controller = useController(map, props, intl);
 
     // Start / Stop measurement on selection change
     useEffect(() => {
@@ -128,7 +128,7 @@ export const Measurement: FC<MeasurementProps> = (props) => {
 };
 
 /** Creates a MeasurementController instance for the given map. */
-function useController(map: MapModel | undefined, props: MeasurementProps, intl: PackageIntl) {
+function useController(map: MapModel, props: MeasurementProps, intl: PackageIntl) {
     const {
         activeFeatureStyle,
         finishedFeatureStyle,
@@ -137,9 +137,6 @@ function useController(map: MapModel | undefined, props: MeasurementProps, intl:
     } = props;
     const [controller, setController] = useState<MeasurementController | undefined>(undefined);
     useEffect(() => {
-        if (!map) {
-            return;
-        }
         const controller = new MeasurementController(map.olMap, {
             getContinueMessage() {
                 return intl.formatMessage({ id: "tooltips.continue" });

--- a/src/packages/overview-map/OverviewMap.tsx
+++ b/src/packages/overview-map/OverviewMap.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box, BoxProps } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { OverviewMap as OlOverviewMap } from "ol/control";
 import OlBaseLayer from "ol/layer/Base";
@@ -41,11 +41,11 @@ export const OverviewMap: FC<OverviewMapProps> = (props) => {
     const { containerProps } = useCommonComponentProps("overview-map", props);
     const intl = useIntl();
 
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const overviewMapControlElem = useRef(null);
 
     useEffect(() => {
-        if (overviewMapControlElem.current && map && olLayer) {
+        if (overviewMapControlElem.current && olLayer) {
             const olMap = map.olMap;
             const overviewMapControl: OlOverviewMap = new OlOverviewMap({
                 className: "ol-overviewmap",

--- a/src/packages/printing/Printing.tsx
+++ b/src/packages/printing/Printing.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Field, HStack, Input } from "@chakra-ui/react";
 import { NativeSelectField, NativeSelectRoot } from "@open-pioneer/chakra-snippets/native-select";
 import { createLogger } from "@open-pioneer/core";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { NotificationService } from "@open-pioneer/notifier";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { PackageIntl } from "@open-pioneer/runtime";
@@ -40,7 +40,7 @@ export const Printing: FC<PrintingProps> = (props) => {
 
     const notifier = useService<NotificationService>("notifier.NotificationService");
 
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const controller = useController(map, intl, viewPadding);
 
     function changeFileFormat(fileFormat: string) {
@@ -138,19 +138,11 @@ export const Printing: FC<PrintingProps> = (props) => {
 /**
  * Create a PrintingController instance to export the map view.
  */
-function useController(
-    map: MapModel | undefined,
-    intl: PackageIntl,
-    viewPadding: ViewPaddingBehavior
-) {
+function useController(map: MapModel, intl: PackageIntl, viewPadding: ViewPaddingBehavior) {
     const printingService = useService<PrintingService>("printing.PrintingService");
     const [controller, setController] = useState<PrintingController | undefined>(undefined);
 
     useEffect(() => {
-        if (!map) {
-            return;
-        }
-
         const controller = new PrintingController(map.olMap, printingService, {
             overlayText: intl.formatMessage({ id: "printingMap" })
         });

--- a/src/packages/result-list/ResultList.tsx
+++ b/src/packages/result-list/ResultList.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
+import { Box } from "@chakra-ui/react";
+import { FormatNumberOptions } from "@formatjs/intl";
 import {
     BaseFeature,
     HighlightOptions,
     MapModelProps,
-    useMapModel,
+    useMapModelValue,
     ZoomOptions
 } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
@@ -12,8 +14,6 @@ import { useIntl } from "open-pioneer:react-hooks";
 import { FC, ReactNode, RefObject, useEffect, useMemo, useRef, useState } from "react";
 import { DataTable } from "./DataTable/DataTable";
 import { createColumns } from "./DataTable/createColumns";
-import { FormatNumberOptions } from "@formatjs/intl";
-import { Box } from "@chakra-ui/react";
 
 /**
  * Configures a column in the result list component.
@@ -201,6 +201,7 @@ export interface ResultListProps extends CommonComponentProps, MapModelProps {
 export const ResultList: FC<ResultListProps> = (props) => {
     const { containerProps } = useCommonComponentProps("result-list", props);
     const intl = useIntl();
+    const map = useMapModelValue(props);
     const {
         input: { data, columns, labelProperty, formatOptions },
         memoizeRows = false,
@@ -212,8 +213,6 @@ export const ResultList: FC<ResultListProps> = (props) => {
         selectionStyle = selectionMode === "single" ? "radio" : "checkbox",
         highlightOptions
     } = props;
-
-    const { map } = useMapModel(props);
 
     if (columns.length === 0) {
         throw Error("No columns were defined. The result list cannot be displayed.");
@@ -240,9 +239,6 @@ export const ResultList: FC<ResultListProps> = (props) => {
     );
 
     useEffect(() => {
-        if (!map) {
-            return;
-        }
         if (enableZoom) {
             map.zoom(data, zoomOptions);
         }

--- a/src/packages/scale-bar/ScaleBar.tsx
+++ b/src/packages/scale-bar/ScaleBar.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { ScaleLine } from "ol/control";
 import { FC, useEffect, useRef } from "react";
@@ -19,11 +19,11 @@ export interface ScaleBarProps extends CommonComponentProps, MapModelProps {
 export const ScaleBar: FC<ScaleBarProps> = (props) => {
     const { displayMode = "line" } = props;
     const { containerProps } = useCommonComponentProps("scale-bar", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const scaleBarElem = useRef(null);
 
     useEffect(() => {
-        if (scaleBarElem.current && map) {
+        if (scaleBarElem.current) {
             const olMap = map.olMap;
             const scaleLine = new ScaleLine({
                 units: "metric",

--- a/src/packages/scale-setter/ScaleSetter.tsx
+++ b/src/packages/scale-setter/ScaleSetter.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Button, Icon, Menu, Portal } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { PackageIntl } from "@open-pioneer/runtime";
@@ -30,7 +30,7 @@ export interface ScaleSetterProps extends CommonComponentProps, MapModelProps {
 export const ScaleSetter: FC<ScaleSetterProps> = (props) => {
     const { scales = DEFAULT_SCALES } = props;
     const { containerProps } = useCommonComponentProps("scale-setter", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
 
     const scaleSelectOptions = useMemo(
@@ -47,7 +47,7 @@ export const ScaleSetter: FC<ScaleSetterProps> = (props) => {
                         )}
                         value={String(scaleValue)}
                         key={scaleValue}
-                        onClick={() => map?.setScale(scaleValue)}
+                        onClick={() => map.setScale(scaleValue)}
                         onFocus={(e) => {
                             // Not available in unit tests
                             e.target?.scrollIntoView?.({
@@ -62,7 +62,7 @@ export const ScaleSetter: FC<ScaleSetterProps> = (props) => {
         [intl, map, scales]
     );
 
-    const activeScale = useReactiveSnapshot(() => map?.scale ?? 1, [map]);
+    const activeScale = useReactiveSnapshot(() => map.scale ?? 1, [map]);
     return (
         <Box {...containerProps}>
             <Menu.Root>

--- a/src/packages/scale-setter/package.json
+++ b/src/packages/scale-setter/package.json
@@ -17,6 +17,7 @@
         "build": "build-pioneer-package"
     },
     "dependencies": {
+        "@conterra/reactivity-core": "catalog:",
         "@chakra-ui/react": "catalog:",
         "@open-pioneer/map": "workspace:^",
         "@open-pioneer/react-utils": "catalog:",

--- a/src/packages/scale-viewer/ScaleViewer.tsx
+++ b/src/packages/scale-viewer/ScaleViewer.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Text, VisuallyHidden } from "@chakra-ui/react";
-import { MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { useIntl } from "open-pioneer:react-hooks";
@@ -14,10 +14,10 @@ export interface ScaleViewerProps extends CommonComponentProps, MapModelProps {}
 
 export const ScaleViewer: FC<ScaleViewerProps> = (props) => {
     const { containerProps } = useCommonComponentProps("scale-viewer", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
 
-    const scale = useReactiveSnapshot(() => map?.scale ?? 1, [map]);
+    const scale = useReactiveSnapshot(() => map.scale ?? 1, [map]);
     const displayScale = intl.formatNumber(scale);
 
     // Make the scale shown to the screen reader lag behind a bit via debounce.

--- a/src/packages/search/Search.tsx
+++ b/src/packages/search/Search.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, chakra, Portal, useToken } from "@chakra-ui/react";
 import { createLogger, isAbortError } from "@open-pioneer/core";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps, useEvent } from "@open-pioneer/react-utils";
 import { PackageIntl } from "@open-pioneer/runtime";
 import {
@@ -113,7 +113,7 @@ export interface SearchProps extends CommonComponentProps, MapModelProps {
 export const Search: FC<SearchProps> = (props) => {
     const { sources, searchTypingDelay, maxResultsPerGroup, onSelect, onClear } = props;
     const { containerProps } = useCommonComponentProps("search", props);
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const intl = useIntl();
     const controller = useController(sources, searchTypingDelay, maxResultsPerGroup, map);
     const { input, search, selectedOption, onInputChanged, onResultConfirmed } =
@@ -327,13 +327,10 @@ function useController(
     sources: SearchSource[],
     searchTypingDelay: number | undefined,
     maxResultsPerGroup: number | undefined,
-    map: MapModel | undefined
+    map: MapModel
 ) {
     const [controller, setController] = useState<SearchController | undefined>(undefined);
     useEffect(() => {
-        if (!map) {
-            return;
-        }
         const controller = new SearchController(map, sources);
         setController(controller);
         return () => {

--- a/src/packages/selection/Selection.tsx
+++ b/src/packages/selection/Selection.tsx
@@ -11,7 +11,7 @@ import {
     VStack
 } from "@chakra-ui/react";
 import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { NotificationService } from "@open-pioneer/notifier";
 import { CommonComponentProps, useCommonComponentProps, useEvent } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
@@ -73,9 +73,9 @@ export const Selection: FC<SelectionProps> = (props) => {
 
     const currentSourceStatus = useSourceStatus(currentSource);
 
-    const mapState = useMapModel(props);
+    const map = useMapModelValue(props);
     const { onExtentSelected } = useSelectionController(
-        mapState.map,
+        map,
         sources,
         currentSource,
         onSelectionComplete
@@ -85,7 +85,7 @@ export const Selection: FC<SelectionProps> = (props) => {
     const hasSelectedSource = !!currentSource;
 
     const dragController = useDragSelection(
-        mapState.map,
+        map,
         intl,
         onExtentSelected,
         isActive,
@@ -259,7 +259,7 @@ function SelectionSourceItem(props: { source: SelectionSource | undefined }) {
  * Hook to manage selection controller
  */
 function useSelectionController(
-    mapModel: MapModel | undefined,
+    mapModel: MapModel,
     sources: SelectionSource[],
     currentSource: SelectionSource | undefined,
     onSelectionComplete: ((event: SelectionCompleteEvent) => void) | undefined
@@ -268,9 +268,6 @@ function useSelectionController(
     const intl = useIntl();
     const [controller, setController] = useState<SelectionController | undefined>(undefined);
     useEffect(() => {
-        if (!mapModel) {
-            return;
-        }
         const controller = new SelectionController({
             mapModel,
             onError() {
@@ -346,7 +343,7 @@ function useSourceStatus(source: SelectionSource | undefined): SimpleStatus {
  * Hook to manage map controls and tooltip
  */
 function useDragSelection(
-    map: MapModel | undefined,
+    map: MapModel,
     intl: PackageIntl,
     onExtentSelected: (geometry: Geometry) => void,
     isActive: boolean,
@@ -354,10 +351,6 @@ function useDragSelection(
 ): DragController | undefined {
     const [controller, setController] = useState<DragController | undefined>();
     useEffect(() => {
-        if (!map) {
-            return;
-        }
-
         const disabledMessage = hasSelectedSource
             ? intl.formatMessage({ id: "disabledTooltip" })
             : intl.formatMessage({ id: "noSourceTooltip" });

--- a/src/packages/selection/__snapshots__/Selection.test.tsx.snap
+++ b/src/packages/selection/__snapshots__/Selection.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`should successfully create a selection component and select the first s
     >
       <button
         aria-controls="select:«r0»:content"
+        aria-description="disabledTooltip"
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-labelledby="select:«r0»:label"

--- a/src/packages/spatial-bookmarks/SpatialBookmarks.test.tsx
+++ b/src/packages/spatial-bookmarks/SpatialBookmarks.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it } from "vitest";
-import { SpatialBookmarks } from "./SpatialBookmarks";
+import { SpatialBookmarks, SpatialBookmarksProps } from "./SpatialBookmarks";
 import { Bookmark } from "./SpatialBookmarksViewModel";
 
 const MOCK_NAMESPACE_CONTENT = new Map<string, unknown>();
@@ -164,36 +164,29 @@ interface CtxProviderConfig {
     "local-storage.LocalStorageService": Partial<LocalStorageService>;
 }
 
-interface ComponentPropsConfig {
-    mapId: string;
-    "data-testid": string;
-}
-
 async function createBookmarkComponent() {
-    const { mapId, mapModel, injectedServices } = await setupComponent();
-    renderComponent({ services: injectedServices }, { mapId: mapId, "data-testid": "bookmarks" });
+    const { mapModel, injectedServices } = await setupComponent();
+    renderComponent({ services: injectedServices }, { map: mapModel, "data-testid": "bookmarks" });
     const div = await waitForSpatialBookmarks();
-    return { mapId, mapModel, div };
+    return { mapModel, div };
 }
 
 async function setupComponent() {
-    const { mapId, registry } = await setupMap({
+    const { map, registry } = await setupMap({
         projection: "EPSG:25832"
     });
-    const mapModel = await registry.expectMapModel(mapId);
     const injectedServices = {
         ...createServiceOptions({ registry }),
         "local-storage.LocalStorageService": MOCK_STORAGE_SERVICE
     };
     return {
-        mapModel,
-        mapId,
+        mapModel: map,
         injectedServices
     };
 }
 function renderComponent(
     contextProviderProps: { services: CtxProviderConfig },
-    componentProps: ComponentPropsConfig
+    componentProps: SpatialBookmarksProps
 ) {
     return render(
         <PackageContextProvider {...contextProviderProps}>

--- a/src/packages/spatial-bookmarks/SpatialBookmarks.tsx
+++ b/src/packages/spatial-bookmarks/SpatialBookmarks.tsx
@@ -18,7 +18,7 @@ import {
 import { Alert } from "@open-pioneer/chakra-snippets/alert";
 import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
 import { LocalStorageService } from "@open-pioneer/local-storage";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import { CommonComponentProps, useCommonComponentProps } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { PackageIntl } from "@open-pioneer/runtime";
@@ -36,7 +36,7 @@ export interface SpatialBookmarksProps extends CommonComponentProps, MapModelPro
  * A component that allows the user to manage a set of spatial bookmarks.
  */
 export const SpatialBookmarks: FC<SpatialBookmarksProps> = (props) => {
-    const { map } = useMapModel(props);
+    const map = useMapModelValue(props);
     const localStorageService = useService<LocalStorageService>(
         "local-storage.LocalStorageService"
     );
@@ -393,16 +393,10 @@ function DialogIconButton(props: IconButtonProps): ReactNode {
     return <IconButton flex="0 0 auto" px={4} {...props} />;
 }
 
-function useViewModel(map: MapModel | undefined, localStorageService: LocalStorageService) {
+function useViewModel(map: MapModel, localStorageService: LocalStorageService) {
     const [viewModel, setViewModel] = useState<SpatialBookmarkViewModel>();
     useEffect(() => {
-        let viewModel: SpatialBookmarkViewModel | undefined;
-        if (!map) {
-            viewModel = undefined;
-        } else {
-            viewModel = new SpatialBookmarkViewModel(map, localStorageService);
-        }
-
+        const viewModel = new SpatialBookmarkViewModel(map, localStorageService);
         setViewModel(viewModel);
         return () => viewModel?.destroy();
     }, [map, localStorageService]);

--- a/src/packages/toc/i18n/de.yaml
+++ b/src/packages/toc/i18n/de.yaml
@@ -9,7 +9,6 @@ messages:
     expand: "Gruppe {title} ausklappen"
     collapse: "Gruppe {title} einklappen"
 
-  error: "Beim Erstellen des Karteninhalts ist ein Fehler aufgetreten."
   layerNotAvailable: "Layer nicht verfügbar"
 
   toolsLabel: "Kartenwerkzeuge"

--- a/src/packages/toc/i18n/en.yaml
+++ b/src/packages/toc/i18n/en.yaml
@@ -9,7 +9,6 @@ messages:
     expand: "Expand group {title}"
     collapse: "Collapse group {title}"
 
-  error: "Error while creating map content."
   layerNotAvailable: "Layer not available"
 
   toolsLabel: "Map tools"

--- a/src/packages/toc/ui/LayerList/LayerList.test.tsx
+++ b/src/packages/toc/ui/LayerList/LayerList.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { nextTick } from "@conterra/reactivity-core";
 import { GroupLayer, SimpleLayer } from "@open-pioneer/map";
-import { setupMap } from "@open-pioneer/map-test-utils";
+import { LayerConfig, setupMap } from "@open-pioneer/map-test-utils";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 import {
     fireEvent,
@@ -22,7 +22,7 @@ import { TocModel, TocModelProvider, TocWidgetOptions } from "../../model/TocMod
 import { TopLevelLayerList } from "./LayerList";
 
 it("should show layers in the correct order", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "Layer 1",
@@ -38,10 +38,9 @@ it("should show layers in the correct order", async () => {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     /*
@@ -59,7 +58,7 @@ it("should show layers in the correct order", async () => {
 });
 
 it("does not display base layers", async function () {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "Layer 1",
@@ -72,10 +71,9 @@ it("does not display base layers", async function () {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const labels = getCurrentLabels(container);
@@ -83,7 +81,7 @@ it("does not display base layers", async function () {
 });
 
 it("shows a single entry for layer groups inside a SimpleLayer", async function () {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "Layer 1",
@@ -95,10 +93,9 @@ it("shows a single entry for layer groups inside a SimpleLayer", async function 
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const labels = getCurrentLabels(container);
@@ -106,20 +103,19 @@ it("shows a single entry for layer groups inside a SimpleLayer", async function 
 });
 
 it("shows a fallback message if there are no layers", async function () {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: []
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     expect(container.textContent).toBe("missingLayers");
 });
 
 it("reacts to changes in the layer composition", async function () {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "Layer 1",
@@ -127,10 +123,8 @@ it("reacts to changes in the layer composition", async function () {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
-
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const initialItems = getCurrentItems(container);
@@ -154,7 +148,7 @@ it("reacts to changes in the layer composition", async function () {
 });
 
 it("displays the layer's current title", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -164,14 +158,13 @@ it("displays the layer's current title", async () => {
         ]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     expect(getCurrentLabels(container)).toEqual(["Layer 1"]);
@@ -183,7 +176,7 @@ it("displays the layer's current title", async () => {
 });
 
 it("displays the layer's current visibility", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -193,7 +186,6 @@ it("displays the layer's current visibility", async () => {
         ]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
@@ -201,7 +193,7 @@ it("displays the layer's current visibility", async () => {
     expect(layer.visible).toBe(true);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const checkbox = queryByRole<HTMLInputElement>(container, "checkbox");
@@ -217,7 +209,7 @@ it("displays the layer's current visibility", async () => {
 
 it("changes the layer's visibility when toggling the checkbox", async () => {
     const user = userEvent.setup();
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -227,14 +219,13 @@ it("changes the layer's visibility when toggling the checkbox", async () => {
         ]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     // Initial state reflects layer state (visible)
@@ -255,7 +246,7 @@ it("changes the layer's visibility when toggling the checkbox", async () => {
 });
 
 it("includes the layer id in the item's class list", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "some layer id",
@@ -264,10 +255,9 @@ it("includes the layer id in the item's class list", async () => {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const item = container.querySelector(".layer-some-layer-id");
@@ -276,7 +266,7 @@ it("includes the layer id in the item's class list", async () => {
 });
 
 it("renders buttons for all layer's with description property", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "Layer 1",
@@ -289,10 +279,9 @@ it("renders buttons for all layer's with description property", async () => {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const initialItems = queryAllByRole(container, "button");
@@ -300,7 +289,7 @@ it("renders buttons for all layer's with description property", async () => {
 });
 
 it("changes the description popover's visibility when toggling the button", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -314,14 +303,14 @@ it("changes the description popover's visibility when toggling the button", asyn
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
+
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const button = queryByRole(container, "button");
@@ -348,7 +337,7 @@ it("changes the description popover's visibility when toggling the button", asyn
 });
 
 it("reacts to changes in the layer description", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer1",
@@ -363,14 +352,14 @@ it("reacts to changes in the layer description", async () => {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
+
     const layer = map.layers.getLayerById("layer1");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const initialItems = queryAllByRole(container, "button");
@@ -393,7 +382,7 @@ it("reacts to changes in the layer description", async () => {
 it("reacts to changes of the layer load state", async () => {
     const source = new OSM();
 
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer1",
@@ -405,10 +394,9 @@ it("reacts to changes of the layer load state", async () => {
             }
         ]
     });
-    const map = await registry.expectMapModel(mapId);
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     const checkbox = queryByRole<HTMLInputElement>(container, "checkbox")!;
@@ -446,15 +434,15 @@ it("supports a hierarchy of layers", async () => {
     const user = userEvent.setup();
 
     const { group, subgroup, submember } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
-        layers: [group]
+    const { map, Wrapper } = await setup({
+        layers: [group],
+        tocOptions: {
+            autoShowParents: true
+        }
     });
 
-    const map = await registry.expectMapModel(mapId);
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({
-            autoShowParents: true
-        })
+        wrapper: Wrapper
     });
 
     // Check hierarchy of dom elements
@@ -492,15 +480,15 @@ it("supports disabling autoShowParents", async () => {
     const user = userEvent.setup();
 
     const { group, subgroup, submember } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
-        layers: [group]
+    const { map, Wrapper } = await setup({
+        layers: [group],
+        tocOptions: {
+            autoShowParents: false
+        }
     });
 
-    const map = await registry.expectMapModel(mapId);
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({
-            autoShowParents: false
-        })
+        wrapper: Wrapper
     });
 
     const submemberItem = findLayerItem(container, "submember")!;
@@ -524,15 +512,15 @@ it("supports disabling autoShowParents", async () => {
 it("should collapse and expand list items", async () => {
     const user = userEvent.setup();
     const { group } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
-        layers: [group]
+    const { map, Wrapper } = await setup({
+        layers: [group],
+        tocOptions: {
+            collapsibleGroups: true
+        }
     });
 
-    const map = await registry.expectMapModel(mapId);
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({
-            collapsibleGroups: true
-        })
+        wrapper: Wrapper
     });
 
     const groupItem = findLayerItem(container, "group")!;
@@ -556,7 +544,7 @@ it("should collapse and expand list items", async () => {
 
 it("it renders collapse buttons (only) for groups", async () => {
     const { group } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 title: "SimpleLayer",
@@ -564,12 +552,14 @@ it("it renders collapse buttons (only) for groups", async () => {
                 olLayer: new TileLayer({})
             },
             group
-        ]
+        ],
+        tocOptions: {
+            collapsibleGroups: true
+        }
     });
 
-    const map = await registry.expectMapModel(mapId);
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({ collapsibleGroups: true })
+        wrapper: Wrapper
     });
 
     const groupItem = findLayerItem(container, "group")!;
@@ -589,16 +579,16 @@ it("it renders collapse buttons (only) for groups", async () => {
 
 it("supports disabling collapsibleGroups, even if `initiallyCollapsed` is `true`", async () => {
     const { group } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
-        layers: [group]
-    });
-
-    const map = await registry.expectMapModel(mapId);
-    const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({
+    const { map, Wrapper } = await setup({
+        layers: [group],
+        tocOptions: {
             collapsibleGroups: false,
             initiallyCollapsed: true
-        })
+        }
+    });
+
+    const { container } = render(<TopLevelLayerList map={map} />, {
+        wrapper: Wrapper
     });
 
     const groupItem = findLayerItem(container, "group")!;
@@ -615,16 +605,16 @@ it("supports disabling collapsibleGroups, even if `initiallyCollapsed` is `true`
 it("supports initial collapsed groups", async () => {
     const user = userEvent.setup();
     const { group } = createGroupHierarchy();
-    const { mapId, registry } = await setupMap({
-        layers: [group]
-    });
-
-    const map = await registry.expectMapModel(mapId);
-    const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper({
+    const { map, Wrapper } = await setup({
+        layers: [group],
+        tocOptions: {
             collapsibleGroups: true,
             initiallyCollapsed: true
-        })
+        }
+    });
+
+    const { container } = render(<TopLevelLayerList map={map} />, {
+        wrapper: Wrapper
     });
 
     const groupItem = findLayerItem(container, "group")!;
@@ -643,7 +633,7 @@ it("supports initial collapsed groups", async () => {
 });
 
 it("displays the layer item only if the layer is not internal", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -654,14 +644,13 @@ it("displays the layer item only if the layer is not internal", async () => {
         ]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     let layerItem = findLayerItem(container, layer.id);
@@ -676,7 +665,7 @@ it("displays the layer item only if the layer is not internal", async () => {
 });
 
 it("displays the layer item only if the list mode is not `hide`", async () => {
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [
             {
                 id: "layer",
@@ -692,14 +681,13 @@ it("displays the layer item only if the list mode is not `hide`", async () => {
         ]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const layer = map.layers.getLayerById("layer");
     if (!layer) {
         throw new Error("test layer not found!");
     }
 
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     let layerItem = findLayerItem(container, layer.id);
@@ -758,13 +746,12 @@ it("does not display layer item for child layer if the group's listMode is `hide
         }
     });
 
-    const { mapId, registry } = await setupMap({
+    const { map, Wrapper } = await setup({
         layers: [groupLayer]
     });
 
-    const map = await registry.expectMapModel(mapId);
     const { container } = render(<TopLevelLayerList map={map} />, {
-        wrapper: createWrapper()
+        wrapper: Wrapper
     });
 
     let groupLayerItem = findLayerItem(container, groupLayer.id);
@@ -832,24 +819,31 @@ function createGroupHierarchy() {
     return { group, subgroup, submember };
 }
 
-function createWrapper(options?: Partial<TocWidgetOptions>) {
+async function setup(opts?: { layers?: LayerConfig[]; tocOptions?: Partial<TocWidgetOptions> }) {
+    const { map } = await setupMap({
+        layers: opts?.layers
+    });
+
     const testModel: TocModel = {
         options: {
             autoShowParents: true,
             collapsibleGroups: false,
             initiallyCollapsed: false,
-            ...options
+            ...opts?.tocOptions
         },
         getItem: () => undefined,
         getItems: () => [],
         registerItem: () => undefined,
         unregisterItem: () => undefined
     };
-    return function Wrapper(props: { children: ReactNode }) {
+
+    function Wrapper(props: { children?: ReactNode }) {
         return (
             <PackageContextProvider>
                 <TocModelProvider value={testModel}>{props.children}</TocModelProvider>
             </PackageContextProvider>
         );
-    };
+    }
+
+    return { map, Wrapper };
 }

--- a/src/packages/toc/ui/Toc.tsx
+++ b/src/packages/toc/ui/Toc.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
+import { Box, Flex, Spacer, Text } from "@chakra-ui/react";
 import { reactive, reactiveMap } from "@conterra/reactivity-core";
 import { BasemapSwitcher, BasemapSwitcherProps } from "@open-pioneer/basemap-switcher";
-import { Box, Flex, Spacer, Text } from "@chakra-ui/react";
-import { MapModel, MapModelProps, useMapModel } from "@open-pioneer/map";
+import { MapModel, MapModelProps, useMapModelValue } from "@open-pioneer/map";
 import {
     CommonComponentProps,
     SectionHeading,
@@ -11,7 +11,7 @@ import {
     useCommonComponentProps
 } from "@open-pioneer/react-utils";
 import { useIntl } from "open-pioneer:react-hooks";
-import { FC, ReactNode, useEffect, useId, useMemo, useRef } from "react";
+import { FC, useEffect, useId, useMemo, useRef } from "react";
 import { TocItem, TocModel, TocModelProvider, TocWidgetOptions } from "../model/TocModel";
 import { TopLevelLayerList } from "./LayerList/LayerList";
 import { Tools } from "./Tools";
@@ -113,28 +113,12 @@ const PADDING = 2;
  * Displays the layers of the configured map.
  */
 export const Toc: FC<TocProps> = (props: TocProps) => {
-    const intl = useIntl();
     const { containerProps } = useCommonComponentProps("toc", props);
-    const state = useMapModel(props);
-
-    let content: ReactNode | null;
-    switch (state.kind) {
-        case "loading":
-            content = null;
-            break;
-        case "rejected":
-            content = <Text className="toc-error">{intl.formatMessage({ id: "error" })}</Text>;
-            break;
-        case "resolved": {
-            const map = state.map;
-            content = <TocContent {...props} map={map} />;
-            break;
-        }
-    }
+    const map = useMapModelValue(props);
 
     return (
         <Flex {...containerProps} direction="column" gap={PADDING}>
-            {content}
+            <TocContent {...props} map={map} />
         </Flex>
     );
 };

--- a/src/packages/toc/ui/__snapshots__/Toc.test.tsx.snap
+++ b/src/packages/toc/ui/__snapshots__/Toc.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`should successfully create a toc component 1`] = `
         data-part="root"
         data-scope="select"
         dir="ltr"
-        id="select:«r7»"
+        id="select:«r1»"
       >
         <div
           class="chakra-select__control css-17j1053"
@@ -30,10 +30,10 @@ exports[`should successfully create a toc component 1`] = `
           data-scope="select"
           data-state="open"
           dir="ltr"
-          id="select:«r7»:control"
+          id="select:«r1»:control"
         >
           <button
-            aria-controls="select:«r7»:content"
+            aria-controls="select:«r1»:content"
             aria-expanded="true"
             aria-haspopup="listbox"
             aria-labelledby="«r0»"
@@ -43,7 +43,7 @@ exports[`should successfully create a toc component 1`] = `
             data-scope="select"
             data-state="open"
             dir="ltr"
-            id="select:«r7»:trigger"
+            id="select:«r1»:trigger"
             role="combobox"
             type="button"
           >
@@ -118,13 +118,13 @@ exports[`should successfully create a toc component 1`] = `
             data-scope="checkbox"
             data-state="checked"
             dir="ltr"
-            for="checkbox:«r2»:input"
-            id="checkbox:«r2»"
+            for="checkbox:«r3»:input"
+            id="checkbox:«r3»"
           >
             <input
-              aria-labelledby="checkbox:«r2»:label"
+              aria-labelledby="checkbox:«r3»:label"
               checked=""
-              id="checkbox:«r2»:input"
+              id="checkbox:«r3»:input"
               style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
               type="checkbox"
               value="on"
@@ -136,7 +136,7 @@ exports[`should successfully create a toc component 1`] = `
               data-scope="checkbox"
               data-state="checked"
               dir="ltr"
-              id="checkbox:«r2»:control"
+              id="checkbox:«r3»:control"
             >
               <svg
                 class="css-wuqtn7"
@@ -154,7 +154,7 @@ exports[`should successfully create a toc component 1`] = `
               data-scope="checkbox"
               data-state="checked"
               dir="ltr"
-              id="checkbox:«r2»:label"
+              id="checkbox:«r3»:label"
             >
               Layer 2
             </span>
@@ -177,13 +177,13 @@ exports[`should successfully create a toc component 1`] = `
             data-scope="checkbox"
             data-state="checked"
             dir="ltr"
-            for="checkbox:«r5»:input"
-            id="checkbox:«r5»"
+            for="checkbox:«r6»:input"
+            id="checkbox:«r6»"
           >
             <input
-              aria-labelledby="checkbox:«r5»:label"
+              aria-labelledby="checkbox:«r6»:label"
               checked=""
-              id="checkbox:«r5»:input"
+              id="checkbox:«r6»:input"
               style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
               type="checkbox"
               value="on"
@@ -195,7 +195,7 @@ exports[`should successfully create a toc component 1`] = `
               data-scope="checkbox"
               data-state="checked"
               dir="ltr"
-              id="checkbox:«r5»:control"
+              id="checkbox:«r6»:control"
             >
               <svg
                 class="css-wuqtn7"
@@ -213,7 +213,7 @@ exports[`should successfully create a toc component 1`] = `
               data-scope="checkbox"
               data-state="checked"
               dir="ltr"
-              id="checkbox:«r5»:label"
+              id="checkbox:«r6»:label"
             >
               Layer 1
             </span>


### PR DESCRIPTION
- Remove `mapId` from react component 
- Introduce new hook `useMapModelValue` (returns map model directly instead of an async result). Name is not final, feedback 
- Update many tests

For more documentation, see changesets.

Issue: #398 