### PR TITLE
Use calculateBufferedExtent instead (highlights buffer) -- see reference #392

### DIFF
--- a/.changeset/little-crabs-relax.md
+++ b/.changeset/little-crabs-relax.md
@@ -1,0 +1,6 @@
+---
+"@open-pioneer/map": patch
+---
+
+We use the already existing calculateBufferedExtent instead of the highlights buffer.
+Use the `buffer` to specify the size increase. E.g. `1.1` for 10% size increase.

--- a/src/packages/map/api/MapModel.ts
+++ b/src/packages/map/api/MapModel.ts
@@ -44,8 +44,8 @@ export interface ZoomOptions {
     viewPadding?: MapPadding;
 
     /**
-     * The buffer factor around the extent of the zoomed features. E.g. a value of 0.1 will add 10%
-     * of the extent's width and height to the extent.
+     * The buffer factor around the extent of the zoomed features. E.g. a value of 1.1 will add
+     * 10% to specify the size increase of the extent's width and height.
      */
     buffer?: number;
 }

--- a/src/packages/map/model/Highlights.test.ts
+++ b/src/packages/map/model/Highlights.test.ts
@@ -107,7 +107,7 @@ it("should successfully zoom with buffered geometries", async () => {
     const zoomLevel2 = map.getView().getZoom();
     expect(zoomLevel2).toBeTruthy();
 
-    highlights.zoomToHighlight([line], { buffer: 1 });
+    highlights.zoomToHighlight([line], { buffer: 1.2 });
     const zoomLevel2WithBuffer = map.getView().getZoom();
     expect(zoomLevel2WithBuffer).toBeTruthy();
     expect(zoomLevel2WithBuffer).not.toEqual(zoomLevel2);

--- a/src/packages/map/model/Highlights.ts
+++ b/src/packages/map/model/Highlights.ts
@@ -20,9 +20,8 @@ import {
 } from "../api/MapModel";
 import mapMarkerUrl from "../assets/images/mapMarker.png?url";
 import { FeatureLike } from "ol/Feature";
-import { TOPMOST_LAYER_Z } from "../api";
+import { calculateBufferedExtent, TOPMOST_LAYER_Z } from "../api";
 import { Type } from "ol/geom/Geometry";
-import { buffer } from "ol/extent";
 
 type HighlightStyleType = keyof HighlightStyle;
 
@@ -145,13 +144,8 @@ export class Highlights {
         }
 
         const bufferParameter = options?.buffer;
-        if (typeof bufferParameter === "number" && extent.length === 4) {
-            // calculate the buffer size based on the maximum dimension of the extent
-            const width = extent[2] && extent[0] ? extent[2] - extent[0] : 0;
-            const height = extent[3] && extent[1] ? extent[3] - extent[1] : 0;
-            const maxDim = Math.max(width, height);
-            const bufferSize = maxDim * bufferParameter; //bufferSize in map units for ol buffer function
-            extent = buffer(extent, bufferSize);
+        if (typeof bufferParameter === "number") {
+            extent = calculateBufferedExtent(extent, bufferParameter);
         }
 
         const center = getCenter(extent);

--- a/src/samples/test-highlight-and-zoom/highlight-and-zoom-app/AppUI.tsx
+++ b/src/samples/test-highlight-and-zoom/highlight-and-zoom-app/AppUI.tsx
@@ -77,12 +77,12 @@ export function AppUI() {
             if (ownStyle) {
                 const highlight = map.highlightAndZoom(resultGeometries, {
                     highlightStyle: ownHighlightStyle,
-                    buffer: 0.1
+                    buffer: 1.1
                 });
                 if (highlight) highlightMap.current.set(id, highlight);
             } else {
                 const highlight = map.highlightAndZoom(resultGeometries, {
-                    buffer: 0.1
+                    buffer: 1.1
                 });
                 if (highlight) highlightMap.current.set(id, highlight);
             }


### PR DESCRIPTION
See #392

We use the already existing calculateBufferedExtent instead of the highlights buffer.
Use the `buffer` to specify the size increase. E.g. `1.1` for 10% size increase.
