### PR TITLE
Fix #587 - [map] Map center is not animated correctly if view padding changes multiple times in short succession

### DIFF
--- a/.changeset/hot-years-raise.md
+++ b/.changeset/hot-years-raise.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map": patch
+---
+
+#587 - [map] Map center is not animated correctly if view padding changes multiple times in short succession

--- a/.changeset/hot-years-raise.md
+++ b/.changeset/hot-years-raise.md
@@ -2,4 +2,4 @@
 "@open-pioneer/map": patch
 ---
 
-#587 - [map] Map center is not animated correctly if view padding changes multiple times in short succession
+Fix map center / map extent not being animated correctly if view padding changes multiple times in short succession (see [#587](https://github.com/open-pioneer/trails-openlayers-base-packages/issues/587)).

--- a/src/packages/map/ui/MapContainer.test.tsx
+++ b/src/packages/map/ui/MapContainer.test.tsx
@@ -116,6 +116,61 @@ it("does update view padding on map if padding values are changed", async () => 
     expect(changeFired).toBe(true);
 });
 
+it("does keep center if padding is changed during animation", async () => {
+    const initialPadding = { top: 10, right: 20, bottom: 30, left: 40 };
+    const { map, rerender } = await renderMap({
+        viewPadding: initialPadding
+    });
+
+    // expect initial padding is set
+    expect(map.olView.padding).toEqual([10, 20, 30, 40]);
+    await map.whenDisplayed();
+
+    // update with changed padding
+    const centerValuesDuringAnimation: any[] = [];
+    map.olView.on("change:center", () => {
+        centerValuesDuringAnimation.push(map.olView.getCenter());
+    });
+    const currentCenter = map.olView.getCenter();
+
+    rerender({
+        viewPadding: {
+            ...initialPadding,
+            top: 15
+        }
+    });
+
+    // expect padding is changed
+    expect(map.olView.padding).toEqual([15, 20, 30, 40]);
+
+    // change of padding triggers set of new center
+    await vi.waitFor(() => {
+        expect(centerValuesDuringAnimation.length).toBeGreaterThan(0);
+    });
+
+    // animation to "old center" is still running
+    expect(map.olView.getAnimating()).toBe(true);
+
+    // update padding again during animation
+    rerender({
+        viewPadding: {
+            ...initialPadding,
+            top: 25
+        }
+    });
+
+    // padding is updated immediately
+    expect(map.olView.padding).toEqual([25, 20, 30, 40]);
+
+    // wait until animation is finished
+    await vi.waitFor(() => {
+        expect(map.olView.getAnimating()).toBe(false);
+    });
+
+    // the center during the animation is still the original center of the first padding change
+    expect(centerValuesDuringAnimation.pop()).toEqual(currentCenter);
+});
+
 it("reports an error if two map containers are used for the same map", async () => {
     const logSpy = vi.spyOn(global.console, "error").mockImplementation(() => undefined);
     const { map } = await setupMap();

--- a/src/packages/map/ui/MapContainer.tsx
+++ b/src/packages/map/ui/MapContainer.tsx
@@ -16,6 +16,7 @@ import { DISPLAY_STATUS, MapModel, MapPadding } from "../model/MapModel";
 import { MapContainerContextProvider, MapContainerContextType } from "./MapContainerContext";
 import { MapModelProps, useMapModelValue } from "./hooks/useMapModel";
 import { OverlaysRenderer } from "./OverlaysRenderer";
+import { Coordinate } from "ol/coordinate";
 
 const LOG = createLogger(sourceId);
 
@@ -270,6 +271,13 @@ function useSyncViewPadding(
     map: MapModel
 ) {
     const mapView = useReactiveSnapshot(() => map.olView, [map]);
+    const targetViewPoint = useRef<
+        | {
+              center: Coordinate;
+              extent: Extent | undefined;
+          }
+        | undefined
+    >(undefined);
     useEffect(() => {
         const olMap = map.olMap;
         if (!mapView) {
@@ -282,32 +290,54 @@ function useSyncViewPadding(
             return;
         }
 
-        const oldCenter = mapView.getCenter();
-        const oldExtent = extentIncludingPadding(olMap, oldPadding);
+        let target = targetViewPoint.current;
+        if (!target || !mapView.getAnimating()) {
+            const currentCenter = mapView.getCenter();
+            if (!currentCenter) {
+                return;
+            }
+            targetViewPoint.current = target = {
+                center: currentCenter,
+                extent: extentIncludingPadding(olMap, oldPadding)
+            };
+        }
         mapView.padding = toOlPadding(viewPadding);
 
         const shouldAnimate = map[DISPLAY_STATUS] === "ready";
         switch (viewPaddingChangeBehavior) {
             case "preserve-center": {
                 if (shouldAnimate) {
-                    mapView.animate({ center: oldCenter, duration: 300 });
+                    mapView.animate({ center: target.center, duration: 300 }, (done) => {
+                        if (done) {
+                            targetViewPoint.current = undefined;
+                        }
+                    });
                 } else {
-                    mapView.setCenter(oldCenter);
+                    mapView.setCenter(target.center);
+                    targetViewPoint.current = undefined;
                 }
                 break;
             }
             case "preserve-extent": {
-                if (oldExtent) {
-                    const res = mapView.getResolutionForExtent(oldExtent);
+                if (target.extent) {
+                    const res = mapView.getResolutionForExtent(target.extent);
                     if (shouldAnimate) {
-                        mapView.animate({
-                            center: oldCenter,
-                            resolution: res,
-                            duration: 300
-                        });
+                        mapView.animate(
+                            {
+                                center: target.center,
+                                resolution: res,
+                                duration: 300
+                            },
+                            (done) => {
+                                if (done) {
+                                    targetViewPoint.current = undefined;
+                                }
+                            }
+                        );
                     } else {
-                        mapView.setCenter(oldCenter);
+                        mapView.setCenter(target.center);
                         mapView.setResolution(res);
+                        targetViewPoint.current = undefined;
                     }
                 }
                 break;

--- a/src/packages/map/ui/MapContainer.tsx
+++ b/src/packages/map/ui/MapContainer.tsx
@@ -262,6 +262,11 @@ function useViewPadding(viewPaddingProp: MapPadding | undefined): Required<MapPa
     ]);
 }
 
+interface TargetViewPoint {
+    center: Coordinate;
+    extent: Extent | undefined;
+}
+
 /**
  * Applies the current view padding to the view.
  */
@@ -271,13 +276,10 @@ function useSyncViewPadding(
     map: MapModel
 ) {
     const mapView = useReactiveSnapshot(() => map.olView, [map]);
-    const targetViewPoint = useRef<
-        | {
-              center: Coordinate;
-              extent: Extent | undefined;
-          }
-        | undefined
-    >(undefined);
+
+    // Tracks target state for in-progress animations.
+    const targetViewPoint = useRef<TargetViewPoint>(undefined);
+
     useEffect(() => {
         const olMap = map.olMap;
         if (!mapView) {


### PR DESCRIPTION
Fix for #587 

A ref is used to store the target center/extent at the first padding change.
If the padding is changed and the update animation not finished, then a new update animation is triggered, but with the value of the current running animation. This keeps the target center/extent value stable.