### PR TITLE
Support Dark Mode in Components

### DIFF
--- a/.changeset/calm-kiwis-bet.md
+++ b/.changeset/calm-kiwis-bet.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/selection": patch
+---
+
+minor changes to support dark color mode

--- a/.changeset/crazy-masks-win.md
+++ b/.changeset/crazy-masks-win.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/scale-bar": patch
+---
+
+minor changes to support dark color mode

--- a/.changeset/five-teams-end.md
+++ b/.changeset/five-teams-end.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/result-list": patch
+---
+
+minor changes to support dark color mode

--- a/.changeset/giant-horses-call.md
+++ b/.changeset/giant-horses-call.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/measurement": patch
+---
+
+minor changes to support dark color mode

--- a/.changeset/ninety-cougars-bathe.md
+++ b/.changeset/ninety-cougars-bathe.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/editing": patch
+---
+
+minor changes to support dark color mode

--- a/src/packages/editing/editing.css
+++ b/src/packages/editing/editing.css
@@ -1,8 +1,8 @@
 .editing-tooltip {
     position: relative;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgb(from var(--chakra-colors-bg) r g b / 80%);
     border-radius: 4px;
-    color: black;
+    color: var(--chakra-colors-fg);
     padding: 4px 8px;
     opacity: 1;
     white-space: nowrap;

--- a/src/packages/measurement/measurement.css
+++ b/src/packages/measurement/measurement.css
@@ -1,8 +1,8 @@
 .measurement-tooltip {
     position: relative;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgb(from var(--chakra-colors-bg) r g b / 80%);
     border-radius: 4px;
-    color: black;
+    color: var(--chakra-colors-fg);
     padding: 4px 8px;
     opacity: 1;
     white-space: nowrap;

--- a/src/packages/result-list/result-list.scss
+++ b/src/packages/result-list/result-list.scss
@@ -21,7 +21,7 @@
         position: sticky;
         top: 0;
         z-index: 1;
-        background: var(--chakra-colors-background_body);
+        background: var(--chakra-colors-bg);
     }
 
     th {
@@ -30,7 +30,7 @@
     }
 
     tbody tr:hover {
-        background: var(--chakra-colors-background_light);
+        background: var(--chakra-colors-bg);
     }
 
     // Resizer

--- a/src/packages/scale-bar/ScaleBar.tsx
+++ b/src/packages/scale-bar/ScaleBar.tsx
@@ -37,5 +37,5 @@ export const ScaleBar: FC<ScaleBarProps> = (props) => {
         }
     }, [displayMode, map]);
 
-    return <Box ref={scaleBarElem} backgroundColor="whiteAlpha.800" {...containerProps} />;
+    return <Box ref={scaleBarElem} backgroundColor="bg/80" {...containerProps} />;
 };

--- a/src/packages/scale-bar/__snapshots__/ScaleBar.test.tsx.snap
+++ b/src/packages/scale-bar/__snapshots__/ScaleBar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`should successfully create a scale bar component 1`] = `
 <div
-  class="scale-bar css-1aqd383"
+  class="scale-bar css-7phg9q"
   data-testid="scale-bar"
 >
   <div

--- a/src/packages/selection/selection.css
+++ b/src/packages/selection/selection.css
@@ -5,9 +5,9 @@
 
 .selection-tooltip {
     position: relative;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgb(from var(--chakra-colors-bg) r g b / 80%);
     border-radius: 4px;
-    color: black;
+    color: var(--chakra-colors-fg);
     padding: 4px 8px;
     opacity: 1;
     white-space: nowrap;

--- a/src/samples/showcase/showcase-app/ui/AppUI.tsx
+++ b/src/samples/showcase/showcase-app/ui/AppUI.tsx
@@ -79,8 +79,10 @@ function AppContent(props: { state: AppStateReady }) {
                                     <Box
                                         role="region"
                                         aria-labelledby={headingId}
-                                        bgColor="white"
+                                        bgColor="bg"
+                                        borderColor="border"
                                         borderRadius={10}
+                                        borderWidth="2px"
                                         p={2}
                                         maxW="500px"
                                     >
@@ -105,12 +107,12 @@ function AppContent(props: { state: AppStateReady }) {
                                     aria-label={intl.formatMessage({ id: "ariaLabels.results" })}
                                     position="absolute"
                                     bottom="0"
-                                    backgroundColor="white"
+                                    backgroundColor="bg"
                                     width="100%"
                                     height="400px"
                                     zIndex={1 /* above map */}
-                                    borderTop="2px solid"
-                                    borderColor="trails.100"
+                                    borderTopWidth="2px"
+                                    borderColor="border"
                                 >
                                     {currentListContainer}
                                 </Box>

--- a/src/samples/showcase/showcase-app/ui/Header/Header.tsx
+++ b/src/samples/showcase/showcase-app/ui/Header/Header.tsx
@@ -26,7 +26,9 @@ export function Header({ appModel }: HeaderProps) {
             alignItems="baseline"
             gap={2}
             boxShadow="1px 0px 3px rgba(0, 0, 0, 0.5)"
-            bgColor="white"
+            bgColor="bg"
+            borderColor="border"
+            borderBottomWidth="2px"
             zIndex={100 /* above all other normal components */}
         >
             <SectionHeading


### PR DESCRIPTION
Components:
- ResultList:
  - change hover color for table rows to semantic token to prevent white text on white background in dark mode
  - (no color change on hover as in light mode)
- ScaleBar:
  - use semantic token for background color
- Measurement, Editing, Selection
  - use semantic tokens for background and text color in tooltips (Overlays)
 
 
Showcase App:
- use semantic tokens for background color
- add borders to prevent black widget background next to black map background

ToDo:
- new editing