### PR TITLE
Support for custom attribution components

### DIFF
--- a/.changeset/cuddly-bobcats-go.md
+++ b/.changeset/cuddly-bobcats-go.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/map": minor
+---
+
+Add reactive property `mapModel.attributionItems`. This is useful for applications that don't want to rely on OpenLayers' attribution widget.

--- a/.changeset/few-poems-share.md
+++ b/.changeset/few-poems-share.md
@@ -1,0 +1,6 @@
+---
+"@open-pioneer/map": minor
+---
+
+Add `MapConfig.showAttributions` property to explicitly show or hide the default attributions widget.
+`showAttributions: false` is intended for situations where the map's attributions are displayed in a custom widget.

--- a/src/packages/map-test-utils/index.ts
+++ b/src/packages/map-test-utils/index.ts
@@ -54,6 +54,9 @@ export interface SimpleMapOptions {
      */
     layers?: LayerConfig[];
 
+    /** See {@link MapConfig.showAttributions} */
+    showAttributions?: boolean;
+
     /**
      * Overrides fetching of network resources (such as service capabilities).
      */
@@ -160,6 +163,7 @@ export async function setupMap(
                     : createTestLayer({ type: SimpleLayer, ...(config as SimpleLayerConfig) })
             // using map as discriminator (no prototype for Layer)
         ) ?? [createTestLayer()],
+        showAttributions: options?.showAttributions,
         advanced: options?.advanced
     };
 

--- a/src/packages/map/index.ts
+++ b/src/packages/map/index.ts
@@ -88,7 +88,8 @@ export {
     type MapModel,
     type DisplayTarget,
     type MapPadding,
-    type ZoomOptions
+    type ZoomOptions,
+    type AttributionItem
 } from "./model/MapModel";
 export {
     type Highlight,

--- a/src/packages/map/model/MapAttributions.test.tsx
+++ b/src/packages/map/model/MapAttributions.test.tsx
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { effect } from "@conterra/reactivity-core";
+import { setupMap, waitForMapMount } from "@open-pioneer/map-test-utils";
+import { render, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { AttributionItem, MapModel } from "../model/MapModel";
+import { MapContainer, MapContainerProps } from "../ui/MapContainer";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import { PackageContextProvider } from "@open-pioneer/test-utils/react";
+
+it("renders attributions for layers in the map", async () => {
+    const { map } = await setupMap({
+        layers: [
+            {
+                title: "Layer1",
+                olLayer: createAttributionLayer("attr 1")
+            },
+            {
+                title: "Layer2",
+                olLayer: createAttributionLayer("attr 2")
+            }
+        ]
+    });
+
+    const { container } = await renderMap({ map });
+    const attributionsDiv = await getAttributionsContainer(container);
+    const items = getAttributionHtml(attributionsDiv);
+    expect(items).toMatchInlineSnapshot(`
+          [
+            "attr 1",
+            "attr 2",
+          ]
+        `);
+    expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "attr 1",
+            },
+            {
+              "text": "attr 2",
+            },
+          ]
+        `);
+});
+
+it("allows simple html in attributions", async () => {
+    const rawHtml = `<a href="https://example.com" target="_blank">&copy; ExampleCompany</a>`;
+    const { map } = await setupMap({
+        layers: [
+            {
+                title: "Layer1",
+                olLayer: createAttributionLayer(rawHtml)
+            }
+        ]
+    });
+
+    const { container } = await renderMap({ map });
+    const attributionsDiv = await getAttributionsContainer(container);
+    const items = getAttributionHtml(attributionsDiv);
+    expect(items).toMatchInlineSnapshot(`
+          [
+            "<a href="https://example.com" target="_blank">© ExampleCompany</a>",
+          ]
+        `);
+    expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "<a href="https://example.com" target="_blank">&copy; ExampleCompany</a>",
+            },
+          ]
+        `);
+});
+
+it("sanitizes invalid html", async () => {
+    // This should be escaped
+    const invalidHtml = `<iframe>Foo`;
+
+    // This uses a script tag which should be removed
+    const xssString = `<a href="https://example.com" onclick="alert(1)">Link</a>`;
+
+    const { map } = await setupMap({
+        layers: [
+            {
+                title: "Layer1",
+                olLayer: createAttributionLayer(invalidHtml)
+            },
+            {
+                title: "Layer2",
+                olLayer: createAttributionLayer(xssString)
+            }
+        ]
+    });
+
+    const { container } = await renderMap({ map });
+    const attributionsDiv = await getAttributionsContainer(container);
+    const items = getAttributionHtml(attributionsDiv);
+    expect(items).toMatchInlineSnapshot(`
+          [
+            "&lt;iframe&gt;Foo",
+            "<a href="https://example.com">Link</a>",
+          ]
+        `);
+    expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "&lt;iframe&gt;Foo",
+            },
+            {
+              "text": "<a href="https://example.com">Link</a>",
+            },
+          ]
+        `);
+});
+
+// NOTE: The map must be rendered for attributions API on the MapModel to work
+it("provides reactive attribution items via mapModel.attributionItems", async () => {
+    const { map } = await setupMap({
+        // Explicitly disable the default control to test that the items are still provided
+        showAttributions: false,
+        layers: [
+            {
+                id: "test-layer",
+                title: "Layer1",
+                olLayer: createAttributionLayer("test")
+            }
+        ]
+    });
+    const { container } = await renderMap({ map });
+
+    // attributionItems are provided even if the default attributions widget is not present
+    await expect(() => getAttributionsContainer(container, 25)).rejects.toThrow(
+        /Attribution widget not found in dom/
+    );
+
+    let items: AttributionItem[] = [];
+    effect(() => {
+        items = map.attributionItems;
+    });
+
+    // Layer is visible -> attributions present
+    await vi.waitUntil(() => items.length > 0);
+    expect(items).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "test",
+            },
+          ]
+        `);
+
+    // Attributions gone when layer becomes invisible
+    map.layers.getLayerById("test-layer")!.setVisible(false);
+    await vi.waitUntil(() => items.length === 0);
+});
+
+async function getAttributionsContainer(container: HTMLElement, timeout?: number) {
+    return await waitFor(
+        () => {
+            const div = container.querySelector(".ol-attribution");
+            if (!div) {
+                throw new Error("Attribution widget not found in dom");
+            }
+            return div as HTMLElement;
+        },
+        { timeout }
+    );
+}
+
+function getAttributionHtml(attributionsDiv: HTMLElement) {
+    const list = Array.from(attributionsDiv.querySelector("ul")!.querySelectorAll("li")!);
+    return list.map((item) => item.innerHTML);
+}
+
+function createAttributionLayer(attributions: string) {
+    const vectorSource = new VectorSource({
+        features: []
+    });
+    vectorSource.setAttributions(attributions);
+    return new VectorLayer({ source: vectorSource });
+}
+
+async function renderMap(props?: MapContainerProps & { map: MapModel }) {
+    const getMapContainer = (props?: MapContainerProps) => {
+        return <MapContainer {...props} data-testid="map" />;
+    };
+    const renderResult = render(getMapContainer(props), {
+        wrapper: (props) => <PackageContextProvider {...props} />
+    });
+    await waitForMapMount("map");
+    return renderResult;
+}

--- a/src/packages/map/model/MapAttributions.ts
+++ b/src/packages/map/model/MapAttributions.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { PackageIntl } from "@open-pioneer/runtime";
+import OlMap, { FrameState } from "ol/Map";
+import Attribution from "ol/control/Attribution";
+import { sanitizeHtml } from "../utils/sanitize";
+import { computed, reactive } from "@conterra/reactivity-core";
+import { AttributionItem } from "./MapModel";
+
+export class MapAttributions {
+    #olMap: OlMap;
+
+    /**
+     * When default rendering of attributions is active, we simply display this control on the map (otherwise: hidden).
+     *
+     * The control is always active (even if invisible) because we re-use its rendering code to extract the attribution items.
+     * There is no real API to extract the attributions from OpenLayers, and we don't want to re-implement that logic right now.
+     * We will see if that approach remains stable.
+     */
+    #control: Attribution;
+
+    #attributionStrings = reactive<string[]>([], { equal: shallowEqual });
+
+    // Attribution strings wrapped in objects, for forward compat.
+    #attributionItems = computed<AttributionItem[]>(() =>
+        this.#attributionStrings.value.map((attribution) => ({
+            text: attribution
+        }))
+    );
+
+    constructor(options: {
+        olMap: OlMap;
+        /** false: not rendered */
+        showControl: boolean;
+        intl: PackageIntl;
+    }) {
+        this.#olMap = options.olMap;
+
+        const control = (this.#control = new Attribution({
+            collapsible: false,
+            target: options.showControl ? undefined : createDummyTargetNode()
+        }));
+        interceptAttributions(
+            control,
+            // Called by the attributions widgets as a side effect.
+            // NOTE: this is currently called very often (~ every map render).
+            (attributions) => {
+                this.#attributionStrings.value = attributions;
+            }
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const element = (control as any).element as HTMLElement | undefined;
+        if (element) {
+            element.role = "region";
+            element.ariaLabel = options.intl.formatMessage({ id: "attribution.label" });
+        }
+
+        this.#olMap.addControl(control);
+    }
+
+    destroy() {
+        this.#olMap.removeControl(this.#control);
+        this.#control.dispose();
+    }
+
+    get attributionItems(): AttributionItem[] {
+        return this.#attributionItems.value;
+    }
+}
+
+// Overrides the OpenLayers widget to sanitize HTML attributions and to intercept the computed array of strings.
+// Note that this depends on OpenLayers internals that may change between versions.
+function interceptAttributions(attr: Attribution, onUpdate: (attributions: string[]) => void) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-function-type
+    const originalCollectSourceAttributions = (attr as any).collectSourceAttributions_ as Function;
+    if (!originalCollectSourceAttributions) {
+        throw new Error("Internal error: failed to override attributions widget");
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (attr as any).collectSourceAttributions_ = (frameState: FrameState) => {
+        const rawAttributions = originalCollectSourceAttributions.call(
+            attr,
+            frameState
+        ) as string[];
+        if (!Array.isArray(rawAttributions)) {
+            throw new Error("Internal error: unexpected attributions result (should be an array)");
+        }
+        const sanitizedAttributions = rawAttributions.map((a) => sanitizeHtml(a));
+        onUpdate(sanitizedAttributions);
+        return sanitizedAttributions;
+    };
+}
+
+function createDummyTargetNode() {
+    const node = document.createElement("div");
+    node.style.display = "none";
+    node.className = "map-attribution-dummy-target";
+    return node;
+}
+
+// TODO: generic shallowEqual, deepEqual helpers @open-pioneer/core
+function shallowEqual<T>(a: T[], b: T[]) {
+    return a.length === b.length && a.every((v, i) => v == b[i]);
+}

--- a/src/packages/map/model/MapConfig.ts
+++ b/src/packages/map/model/MapConfig.ts
@@ -4,6 +4,7 @@ import type { MapOptions as OlMapBaseOptions } from "ol/Map";
 import type OlView from "ol/View";
 import type { ViewOptions as OlViewOptions } from "ol/View";
 import type { Layer } from "../layers/unions";
+import type { MapModel } from "./MapModel";
 
 /**
  * Configures an extent.
@@ -124,6 +125,18 @@ export interface MapConfig {
      * Note: base layers are always shown below all operational layers.
      */
     layers?: Layer[];
+
+    /**
+     * Whether to show the default attribution control.
+     *
+     * The default value is `true`, unless `advanced` options are defined.
+     * The default value changes to `false` if `advanced.controls` defined, mostly for backwards compatibility.
+     * If `showDefaultAttributions` is set explicitly to `true` _or_ `false`, that value always has precedence.
+     *
+     * > NOTE: Disabling the default attribution control typically means that you must render the attributions yourself (see {@link MapModel.attributionItems})
+     * > to comply with the terms of service of your map services.
+     */
+    showAttributions?: boolean;
 
     /**
      * Advanced OpenLayers configuration.

--- a/src/packages/map/model/MapModel.ts
+++ b/src/packages/map/model/MapModel.ts
@@ -39,6 +39,8 @@ import { Overlays } from "./Overlays";
 import { getGeometries } from "./getGeometries";
 import { BaseFeature } from "../utils/BaseFeature";
 import { Geometry } from "ol/geom";
+import { PackageIntl } from "@open-pioneer/runtime";
+import { MapAttributions } from "./MapAttributions";
 
 const LOG = createLogger(sourceId);
 
@@ -50,6 +52,8 @@ const DEFAULT_OL_MAX_ZOOM_LEVEL = 20;
 const DEFAULT_VIEW_PADDING = { top: 50, right: 20, bottom: 10, left: 20 };
 
 export const DISPLAY_STATUS = Symbol("DISPLAY_STATUS");
+
+export const UPDATE_ATTRIBUTIONS = Symbol("UPDATE_ATTRIBUTIONS");
 
 const deprecatedHighlights = deprecated({
     name: "MapModel highlight function called",
@@ -107,6 +111,21 @@ export interface MapPadding {
     bottom?: number;
 }
 
+/**
+ * An item that should be displayed as part of the attributions for the map.
+ *
+ * @group MapModel
+ */
+export interface AttributionItem {
+    /**
+     * The attribution's text.
+     *
+     * Note that this property contains raw HTML tags.
+     * The HTML content has been sanitized, so it is safe to display in the user interface.
+     */
+    text: string;
+}
+
 type DisplayStatus = "waiting" | "ready" | "error";
 
 /**
@@ -118,6 +137,7 @@ export class MapModel {
     readonly #id: string;
     readonly #olMap: OlMap;
     readonly #olView: ReadonlyReactive<OlView>;
+    readonly #attributions: MapAttributions;
     readonly #layers = new LayerCollection(this, INTERNAL_CONSTRUCTOR_TAG);
     readonly #highlights: Highlights;
     readonly #tooltips: Overlays;
@@ -129,10 +149,10 @@ export class MapModel {
     readonly #olLoading = reactive(false);
 
     #isDestroyed = false;
-    #container: ReadonlyReactive<HTMLElement | undefined>;
-    #initialExtent = reactive<ExtentConfig>();
-    #viewBindings: ReadonlyReactive<ViewBindings>;
-    #scale: ReadonlyReactive<number | undefined>;
+    readonly #container: ReadonlyReactive<HTMLElement | undefined>;
+    readonly #initialExtent = reactive<ExtentConfig>();
+    readonly #viewBindings: ReadonlyReactive<ViewBindings>;
+    readonly #scale: ReadonlyReactive<number | undefined>;
 
     readonly #abortController = new AbortController();
     #displayStatus: DisplayStatus;
@@ -142,18 +162,26 @@ export class MapModel {
      * @internal
      */
     constructor(
-        properties: {
+        options: {
             id: string;
             olMap: OlMap;
             initialExtent: ExtentConfig | undefined;
+            showDefaultAttributions: boolean;
+            intl: PackageIntl;
             httpService: HttpService;
         },
         tag: InternalConstructorTag
     ) {
         assertInternalConstructor(tag);
 
-        this.#id = properties.id;
-        this.#olMap = properties.olMap;
+        this.#id = options.id;
+        this.#olMap = options.olMap;
+        this.#attributions = new MapAttributions({
+            intl: options.intl,
+            olMap: this.#olMap,
+            showControl: options.showDefaultAttributions
+        });
+
         this.#olView = synchronized(
             () => this.#olMap.getView(),
             (cb) => {
@@ -165,9 +193,9 @@ export class MapModel {
         // NOTE: As early as possible (before any async actions) so we don't miss any events.
         this.#watchLoadingState();
 
-        this.#initialExtent.value = properties.initialExtent;
+        this.#initialExtent.value = options.initialExtent;
         this.#layerDeps = {
-            httpService: properties.httpService
+            httpService: options.httpService
         };
 
         this.#displayStatus = "waiting";
@@ -241,6 +269,7 @@ export class MapModel {
         this.#displayWaiter?.reject(new Error("Map model was destroyed."));
         this.#layers.destroy();
         this.#highlights[DESTROY_HIGHLIGHTS]();
+        this.#attributions.destroy();
         this.#olMap.dispose();
     }
 
@@ -352,6 +381,13 @@ export class MapModel {
      */
     get container(): HTMLElement | undefined {
         return this.#container.value;
+    }
+
+    /**
+     * Returns attributions for the current content of the map.
+     */
+    get attributionItems(): AttributionItem[] {
+        return this.#attributions.attributionItems;
     }
 
     /**

--- a/src/packages/map/model/MapModel.ts
+++ b/src/packages/map/model/MapModel.ts
@@ -53,8 +53,6 @@ const DEFAULT_VIEW_PADDING = { top: 50, right: 20, bottom: 10, left: 20 };
 
 export const DISPLAY_STATUS = Symbol("DISPLAY_STATUS");
 
-export const UPDATE_ATTRIBUTIONS = Symbol("UPDATE_ATTRIBUTIONS");
-
 const deprecatedHighlights = deprecated({
     name: "MapModel highlight function called",
     packageName: "@open-pioneer/map",

--- a/src/packages/map/model/createMapModel.ts
+++ b/src/packages/map/model/createMapModel.ts
@@ -5,9 +5,8 @@ import { createLogger } from "@open-pioneer/core";
 import { HttpService } from "@open-pioneer/http";
 import { PackageIntl } from "@open-pioneer/runtime";
 import { MapBrowserEvent } from "ol";
-import OlMap, { FrameState, MapOptions } from "ol/Map";
+import OlMap, { MapOptions } from "ol/Map";
 import View, { ViewOptions } from "ol/View";
-import Attribution from "ol/control/Attribution";
 import { getCenter } from "ol/extent";
 import { DragZoom, defaults as defaultInteractions } from "ol/interaction";
 import TileLayer from "ol/layer/Tile";
@@ -19,7 +18,6 @@ import { patchOpenLayersClassesForTesting } from "../utils/ol-test-support";
 import { registerProjections } from "../utils/projections";
 import { MapConfig } from "./MapConfig";
 import { MapModel } from "./MapModel";
-import { sanitizeHtml } from "../utils/sanitize";
 
 /**
  * Register custom projection to the global proj4js definitions. User can select `EPSG:25832`
@@ -59,14 +57,15 @@ class MapModelFactory {
         const mapId = this.mapId;
         const mapConfig = this.mapConfig;
         const { view: viewOption, ...rawOlOptions } = mapConfig.advanced ?? {};
+        const showDefaultAttributions =
+            mapConfig.showAttributions ?? (rawOlOptions.controls ? false : true);
+
         const mapOptions: MapOptions = {
             ...rawOlOptions
         };
-
         if (!mapOptions.controls) {
-            mapOptions.controls = [createDefaultAttribution(this.intl)];
+            mapOptions.controls = [];
         }
-
         if (!mapOptions.interactions) {
             const shiftCtrlKeysOnly = (
                 mapBrowserEvent: MapBrowserEvent<KeyboardEvent | WheelEvent | PointerEvent>
@@ -111,6 +110,8 @@ class MapModelFactory {
                 id: mapId,
                 olMap,
                 initialExtent,
+                showDefaultAttributions,
+                intl: this.intl,
                 httpService: this.httpService
             },
             INTERNAL_CONSTRUCTOR_TAG
@@ -211,35 +212,4 @@ class MapModelFactory {
         }
         return projection;
     }
-}
-
-function createDefaultAttribution(intl: PackageIntl): Attribution {
-    const attr = new Attribution({ collapsible: false });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const element = (attr as any).element as HTMLElement | undefined;
-    if (element) {
-        element.role = "region";
-        element.ariaLabel = intl.formatMessage({ id: "attribution.label" });
-    }
-    sanitizeAttributionsHtml(attr);
-    return attr;
-}
-
-// Overrides the OpenLayers widget to sanitize HTML attributions.
-// Note that this depends on OpenLayers internals that may change between versions.
-function sanitizeAttributionsHtml(attr: Attribution) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-function-type
-    const originalCollectSourceAttributions = (attr as any).collectSourceAttributions_ as Function;
-    if (!originalCollectSourceAttributions) {
-        throw new Error("Internal error: failed to override attributions widget");
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (attr as any).collectSourceAttributions_ = (frameState: FrameState) => {
-        const attributions = originalCollectSourceAttributions.call(attr, frameState) as string[];
-        if (!Array.isArray(attributions)) {
-            throw new Error("Internal error: unexpected attributions result (should be an array)");
-        }
-        return attributions.map((a) => sanitizeHtml(a));
-    };
 }

--- a/src/packages/map/ui/MapContainer.test.tsx
+++ b/src/packages/map/ui/MapContainer.test.tsx
@@ -1,13 +1,15 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { BoxProps } from "@chakra-ui/react";
+import { effect } from "@conterra/reactivity-core";
 import { setupMap, waitForMapMount } from "@open-pioneer/map-test-utils";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 import { render, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { MapContainer, MapContainerProps } from "./MapContainer";
-import VectorSource from "ol/source/Vector";
 import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AttributionItem } from "../model/MapModel";
+import { MapContainer, MapContainerProps } from "./MapContainer";
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -217,18 +219,22 @@ describe("attributions", () => {
         });
 
         const { container } = await renderMap({ map });
-        const attributionsDiv = await waitFor(() => {
-            const div = container.querySelector(".ol-attribution");
-            if (!div) {
-                throw new Error("Attribution widget not found in dom");
-            }
-            return div as HTMLElement;
-        });
+        const attributionsDiv = await getAttributionsContainer(container);
         const items = getAttributionHtml(attributionsDiv);
         expect(items).toMatchInlineSnapshot(`
           [
             "attr 1",
             "attr 2",
+          ]
+        `);
+        expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "attr 1",
+            },
+            {
+              "text": "attr 2",
+            },
           ]
         `);
     });
@@ -245,17 +251,18 @@ describe("attributions", () => {
         });
 
         const { container } = await renderMap({ map });
-        const attributionsDiv = await waitFor(() => {
-            const div = container.querySelector(".ol-attribution");
-            if (!div) {
-                throw new Error("Attribution widget not found in dom");
-            }
-            return div as HTMLElement;
-        });
+        const attributionsDiv = await getAttributionsContainer(container);
         const items = getAttributionHtml(attributionsDiv);
         expect(items).toMatchInlineSnapshot(`
           [
             "<a href="https://example.com" target="_blank">© ExampleCompany</a>",
+          ]
+        `);
+        expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "<a href="https://example.com" target="_blank">&copy; ExampleCompany</a>",
+            },
           ]
         `);
     });
@@ -281,13 +288,7 @@ describe("attributions", () => {
         });
 
         const { container } = await renderMap({ map });
-        const attributionsDiv = await waitFor(() => {
-            const div = container.querySelector(".ol-attribution");
-            if (!div) {
-                throw new Error("Attribution widget not found in dom");
-            }
-            return div as HTMLElement;
-        });
+        const attributionsDiv = await getAttributionsContainer(container);
         const items = getAttributionHtml(attributionsDiv);
         expect(items).toMatchInlineSnapshot(`
           [
@@ -295,7 +296,70 @@ describe("attributions", () => {
             "<a href="https://example.com">Link</a>",
           ]
         `);
+        expect(map.attributionItems).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "&lt;iframe&gt;Foo",
+            },
+            {
+              "text": "<a href="https://example.com">Link</a>",
+            },
+          ]
+        `);
     });
+
+    // NOTE: This test is here because the map most be rendered for attributions to work
+    it("provides reactive attribution items via mapModel.attributionItems", async () => {
+        const { map } = await setupMap({
+            // Explicitly disable the default control to test that the items are still provided
+            showAttributions: false,
+            layers: [
+                {
+                    id: "test-layer",
+                    title: "Layer1",
+                    olLayer: createAttributionLayer("test")
+                }
+            ]
+        });
+        const { container } = await renderMap({ map });
+
+        // attributionItems are provided even if the default attributions widget is not present
+        await expect(() => getAttributionsContainer(container, 25)).rejects.toThrow(
+            /Attribution widget not found in dom/
+        );
+
+        let items: AttributionItem[] = [];
+        effect(() => {
+            items = map.attributionItems;
+        });
+
+        // Layer is visible -> attributions present
+        await vi.waitUntil(() => items.length > 0);
+        expect(items).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "test",
+            },
+          ]
+        `);
+
+        // Attributions gone when layer becomes invisible
+        map.layers.getLayerById("test-layer")!.setVisible(false);
+        await vi.waitUntil(() => items.length === 0);
+    });
+
+    async function getAttributionsContainer(container: HTMLElement, timeout?: number) {
+        return await waitFor(
+            () => {
+                const div = container.querySelector(".ol-attribution");
+                if (!div) {
+                    throw new Error("Attribution widget not found in dom");
+                }
+                return div as HTMLElement;
+            },
+            { timeout }
+        );
+    }
 
     function getAttributionHtml(attributionsDiv: HTMLElement) {
         const list = Array.from(attributionsDiv.querySelector("ul")!.querySelectorAll("li")!);

--- a/src/packages/map/ui/MapContainer.test.tsx
+++ b/src/packages/map/ui/MapContainer.test.tsx
@@ -1,14 +1,10 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { BoxProps } from "@chakra-ui/react";
-import { effect } from "@conterra/reactivity-core";
 import { setupMap, waitForMapMount } from "@open-pioneer/map-test-utils";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
-import { render, waitFor } from "@testing-library/react";
-import VectorLayer from "ol/layer/Vector";
-import VectorSource from "ol/source/Vector";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { AttributionItem } from "../model/MapModel";
+import { render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
 import { MapContainer, MapContainerProps } from "./MapContainer";
 
 afterEach(() => {
@@ -203,170 +199,6 @@ it("reports an error if two map containers are used for the same map", async () 
     `);
 });
 
-describe("attributions", () => {
-    it("renders attributions for layers in the map", async () => {
-        const { map } = await setupMap({
-            layers: [
-                {
-                    title: "Layer1",
-                    olLayer: createAttributionLayer("attr 1")
-                },
-                {
-                    title: "Layer2",
-                    olLayer: createAttributionLayer("attr 2")
-                }
-            ]
-        });
-
-        const { container } = await renderMap({ map });
-        const attributionsDiv = await getAttributionsContainer(container);
-        const items = getAttributionHtml(attributionsDiv);
-        expect(items).toMatchInlineSnapshot(`
-          [
-            "attr 1",
-            "attr 2",
-          ]
-        `);
-        expect(map.attributionItems).toMatchInlineSnapshot(`
-          [
-            {
-              "text": "attr 1",
-            },
-            {
-              "text": "attr 2",
-            },
-          ]
-        `);
-    });
-
-    it("allows simple html in attributions", async () => {
-        const rawHtml = `<a href="https://example.com" target="_blank">&copy; ExampleCompany</a>`;
-        const { map } = await setupMap({
-            layers: [
-                {
-                    title: "Layer1",
-                    olLayer: createAttributionLayer(rawHtml)
-                }
-            ]
-        });
-
-        const { container } = await renderMap({ map });
-        const attributionsDiv = await getAttributionsContainer(container);
-        const items = getAttributionHtml(attributionsDiv);
-        expect(items).toMatchInlineSnapshot(`
-          [
-            "<a href="https://example.com" target="_blank">© ExampleCompany</a>",
-          ]
-        `);
-        expect(map.attributionItems).toMatchInlineSnapshot(`
-          [
-            {
-              "text": "<a href="https://example.com" target="_blank">&copy; ExampleCompany</a>",
-            },
-          ]
-        `);
-    });
-
-    it("sanitizes invalid html", async () => {
-        // This should be escaped
-        const invalidHtml = `<iframe>Foo`;
-
-        // This uses a script tag which should be removed
-        const xssString = `<a href="https://example.com" onclick="alert(1)">Link</a>`;
-
-        const { map } = await setupMap({
-            layers: [
-                {
-                    title: "Layer1",
-                    olLayer: createAttributionLayer(invalidHtml)
-                },
-                {
-                    title: "Layer2",
-                    olLayer: createAttributionLayer(xssString)
-                }
-            ]
-        });
-
-        const { container } = await renderMap({ map });
-        const attributionsDiv = await getAttributionsContainer(container);
-        const items = getAttributionHtml(attributionsDiv);
-        expect(items).toMatchInlineSnapshot(`
-          [
-            "&lt;iframe&gt;Foo",
-            "<a href="https://example.com">Link</a>",
-          ]
-        `);
-        expect(map.attributionItems).toMatchInlineSnapshot(`
-          [
-            {
-              "text": "&lt;iframe&gt;Foo",
-            },
-            {
-              "text": "<a href="https://example.com">Link</a>",
-            },
-          ]
-        `);
-    });
-
-    // NOTE: This test is here because the map most be rendered for attributions to work
-    it("provides reactive attribution items via mapModel.attributionItems", async () => {
-        const { map } = await setupMap({
-            // Explicitly disable the default control to test that the items are still provided
-            showAttributions: false,
-            layers: [
-                {
-                    id: "test-layer",
-                    title: "Layer1",
-                    olLayer: createAttributionLayer("test")
-                }
-            ]
-        });
-        const { container } = await renderMap({ map });
-
-        // attributionItems are provided even if the default attributions widget is not present
-        await expect(() => getAttributionsContainer(container, 25)).rejects.toThrow(
-            /Attribution widget not found in dom/
-        );
-
-        let items: AttributionItem[] = [];
-        effect(() => {
-            items = map.attributionItems;
-        });
-
-        // Layer is visible -> attributions present
-        await vi.waitUntil(() => items.length > 0);
-        expect(items).toMatchInlineSnapshot(`
-          [
-            {
-              "text": "test",
-            },
-          ]
-        `);
-
-        // Attributions gone when layer becomes invisible
-        map.layers.getLayerById("test-layer")!.setVisible(false);
-        await vi.waitUntil(() => items.length === 0);
-    });
-
-    async function getAttributionsContainer(container: HTMLElement, timeout?: number) {
-        return await waitFor(
-            () => {
-                const div = container.querySelector(".ol-attribution");
-                if (!div) {
-                    throw new Error("Attribution widget not found in dom");
-                }
-                return div as HTMLElement;
-            },
-            { timeout }
-        );
-    }
-
-    function getAttributionHtml(attributionsDiv: HTMLElement) {
-        const list = Array.from(attributionsDiv.querySelector("ul")!.querySelectorAll("li")!);
-        return list.map((item) => item.innerHTML);
-    }
-});
-
 async function renderMap(props?: MapContainerProps) {
     let map = props?.map;
     if (!map) {
@@ -388,12 +220,4 @@ async function renderMap(props?: MapContainerProps) {
             renderResult.rerender(getMapContainer(props));
         }
     };
-}
-
-function createAttributionLayer(attributions: string) {
-    const vectorSource = new VectorSource({
-        features: []
-    });
-    vectorSource.setAttributions(attributions);
-    return new VectorLayer({ source: vectorSource });
 }


### PR DESCRIPTION
This PR implements two features necessary for custom attribution components:

1. The `mapModel.attributionItems` property to retrieve the attributions for the current state of the map. The property is reactive.
2. A new option when constructing a map: `MapConfig.showAttributions`. When explicitly set to `false`, the default attributions control will not be displayed on the map.

Example:

```ts
const items = useReactiveSnapshot(() => mapModel.attributionItems, [mapModel]);
// render items in some way
// items[*].text is string that contains (sanitized) HTML
```