### PR TITLE
feature: search and select

### DIFF
--- a/.changeset/slimy-oranges-stare.md
+++ b/.changeset/slimy-oranges-stare.md
@@ -2,4 +2,5 @@
 "@open-pioneer/search": minor
 ---
 
-Add `searchAndSelect` to perform programmatic searches, update search results in the UI, and automatically select the first matching result. The method returns the selected `SearchResult` or `undefined` when no match is found.
+Add `searchAndSelect` to perform programmatic searches, update search results in the UI, and automatically select the first matching result.
+The method returns the selected `SearchResult` (and its `SearchSource`) or `undefined` when no match is found.

--- a/.changeset/slimy-oranges-stare.md
+++ b/.changeset/slimy-oranges-stare.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/search": minor
+---
+
+Add `searchAndSelect` to perform programmatic searches, update search results in the UI, and automatically select the first matching result. The method returns the selected `SearchResult` or `undefined` when no match is found.

--- a/.changeset/sour-buckets-find.md
+++ b/.changeset/sour-buckets-find.md
@@ -1,0 +1,8 @@
+---
+"@open-pioneer/search": minor
+---
+
+The `onSelect` callback now receives an additional property `trigger` (`"user"` or `"api-select"`) support different reactions based on the way a result was selected:
+
+- `user` indicates that event was triggered by the end user
+- `api-select` indicates that the selection was made via the API (i.e. `searchAndSelect`).

--- a/src/packages/search/README.md
+++ b/src/packages/search/README.md
@@ -109,25 +109,28 @@ function onSearchCleared(clearEvent: SearchClearEvent) {
     set search input
 </Button>
 <Button
-    onClick={async () => {
-        const result = await searchApiRef.current?.searchAndSelect("Münster");
-
-        if (!result) {
-            console.log("No matching result found.");
-            return;
-        }
-
-        console.log("Selected result:", result);
-
-        if (!result.geometry) {
-            console.log("Result has no geometry.");
-            return;
-        }
-
-        appModel.highlightAndZoom(map, [result.geometry]);
+    onClick={() => {
+        searchApiRef.current
+            ?.searchAndSelect("Düsseldorf")
+            .then((result) => {
+                if (!result) {
+                    console.debug("No matching result found.");
+                    return;
+                }
+                if (!result.geometry) {
+                    console.log("Result has no geometry.");
+                    return;
+                }
+                appModel.highlightAndZoom(map, [
+                    result.geometry
+                ]);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }}
 >
-    Search and select
+    set and selected search input
 </Button>
 ```
 

--- a/src/packages/search/README.md
+++ b/src/packages/search/README.md
@@ -112,11 +112,13 @@ function onSearchCleared(clearEvent: SearchClearEvent) {
     onClick={() => {
         searchApiRef.current
             ?.searchAndSelect("Düsseldorf")
-            .then((result) => {
-                if (!result) {
+            .then((selection) => {
+                if (!selection) {
                     console.debug("No matching result found.");
                     return;
                 }
+
+                const result = selection.result;
                 if (!result.geometry) {
                     console.log("Result has no geometry.");
                     return;

--- a/src/packages/search/README.md
+++ b/src/packages/search/README.md
@@ -41,7 +41,7 @@ To change the placeholder text of the search field, use the optional property `p
 
 To listen to the events `onSelect` and `onClear`, provide optional callback functions to the component.
 In case of the `onSelect` event, you can access the selected search result (and its search source)
-from the parameter `SelectSearchEvent`.
+from the parameter `SearchSelectEvent`.
 
 ```tsx
 import { Search, SearchClearEvent, SearchSelectEvent } from "@open-pioneer/search";
@@ -58,10 +58,12 @@ import { Search, SearchClearEvent, SearchSelectEvent } from "@open-pioneer/searc
 />;
 ```
 
-The search API allows programmatic access to the search component.
+The search API provides methods to:
 
-Currently, the search API provides a method to clear the search input field.
-Additionally, it provides a method for setting the search input value programmatically without triggering any actions.
+- clear the search input (`resetInput`)
+- set the search input value without triggering a search (`setInputValue`)
+- execute a search and automatically select the first matching result (`searchAndSelect`)
+
 To receive the API, listen to the `onReady` event which provides the `SearchApi` as a parameter once the search component is ready to use:
 
 ```tsx
@@ -106,7 +108,30 @@ function onSearchCleared(clearEvent: SearchClearEvent) {
 >
     set search input
 </Button>
+<Button
+    onClick={async () => {
+        const result = await searchApiRef.current?.searchAndSelect("Münster");
+
+        if (!result) {
+            console.log("No matching result found.");
+            return;
+        }
+
+        console.log("Selected result:", result);
+
+        if (!result.geometry) {
+            console.log("Result has no geometry.");
+            return;
+        }
+
+        appModel.highlightAndZoom(map, [result.geometry]);
+    }}
+>
+    Search and select
+</Button>
 ```
+
+`searchAndSelect` performs a search using the provided query, updates the search UI with the returned results, and automatically selects the first matching result. The returned promise resolves to the selected `SearchResult` or `undefined` if no matching result is found.
 
 ### Positioning the search bar
 

--- a/src/packages/search/api.ts
+++ b/src/packages/search/api.ts
@@ -107,14 +107,24 @@ export interface SearchSelectEvent {
 
     /** The search result selected by the user. */
     result: SearchResult;
+
+    /**
+     * Specifies the trigger that caused the select event.
+     * It can be triggered by the user or through {@link SearchApi.searchAndSelect}.
+     */
+    trigger: SearchSelectTrigger;
 }
+
+export type SearchSelectTrigger = "user" | "api-select";
 
 /**
  * Event type emitted when the search is cleared.
  */
 export interface SearchClearEvent {
-    /** Specifies the trigger that caused the clear event.
-     * The clear can be triggered by the user or through the {@link resetInput} in the SearchAPI. */
+    /**
+     * Specifies the trigger that caused the clear event.
+     * The clear can be triggered by the user or through {@link SearchApi.resetInput}.
+     **/
     trigger: SearchClearTrigger;
 }
 
@@ -143,7 +153,22 @@ export interface SearchApi {
      * @returns A promise that resolves to the selected {@link SearchResult},
      * or `undefined` if no matching result is found or selected.
      */
-    searchAndSelect(inputValue: string): Promise<SearchResult | undefined>;
+    searchAndSelect(inputValue: string): Promise<SelectResult | undefined>;
+}
+
+/**
+ * The result of a select operation via {@link SearchApi.searchAndSelect}.
+ */
+export interface SelectResult {
+    /**
+     * The source that originated the selected result.
+     */
+    source: SearchSource;
+
+    /**
+     * The selected result.
+     */
+    result: SearchResult;
 }
 
 /**

--- a/src/packages/search/api.ts
+++ b/src/packages/search/api.ts
@@ -135,6 +135,15 @@ export interface SearchApi {
      * @param inputValue The value to be set in the search input field.
      */
     setInputValue(inputValue: string): void;
+
+    /**
+     * Searches for the specified input value and selects the matching result.
+     *
+     * @param inputValue - The value to search for.
+     * @returns A promise that resolves to the selected {@link SearchResult},
+     * or `undefined` if no matching result is found or selected.
+     */
+    searchAndSelect(inputValue: string): Promise<SearchResult | undefined>;
 }
 
 /**

--- a/src/packages/search/index.ts
+++ b/src/packages/search/index.ts
@@ -9,6 +9,8 @@ export type {
     SearchReadyEvent,
     SearchResult,
     SearchSelectEvent,
-    SearchSource
+    SearchSelectTrigger,
+    SearchSource,
+    SelectResult
 } from "./api";
 export { Search, type SearchProps } from "./ui/Search";

--- a/src/packages/search/ui/Search.test.tsx
+++ b/src/packages/search/ui/Search.test.tsx
@@ -58,7 +58,8 @@ it("should successfully call select handler after clicking a suggestion", async 
         "result": {
             "id": 0,
             "label": "Dortmund"
-        }
+        },
+        "trigger": "user"
     });
 });
 
@@ -218,24 +219,35 @@ describe("search api", () => {
     });
 
     it("should search and select the first matching result when searchAndSelect is called", async () => {
-        let readyEvent: SearchReadyEvent | undefined;
+        const onSelect = vi.fn();
 
-        await createSearch(undefined, undefined, (e: SearchReadyEvent) => {
+        let readyEvent: SearchReadyEvent | undefined;
+        await createSearch(onSelect, undefined, (e: SearchReadyEvent) => {
             readyEvent = e;
         });
 
         const { searchInput } = await waitForInput();
 
-        const result = await readyEvent!.api.searchAndSelect("Dortmund");
+        const selection = await readyEvent!.api.searchAndSelect("Dortmund");
 
         await waitFor(() => {
             expect(searchInput).toHaveValue("Dortmund");
+            expect(onSelect).toHaveBeenCalled();
         });
 
-        expect(result).toEqual({
+        expect(selection?.result).toEqual({
             id: 0,
             label: "Dortmund"
         });
+        expect(onSelect).toHaveBeenCalledOnce();
+        expect(onSelect).toHaveBeenCalledWith(
+            expect.objectContaining({
+                result: expect.objectContaining({
+                    label: "Dortmund"
+                }),
+                trigger: "api-select"
+            })
+        );
     });
 });
 

--- a/src/packages/search/ui/Search.test.tsx
+++ b/src/packages/search/ui/Search.test.tsx
@@ -226,7 +226,7 @@ describe("search api", () => {
 
         const { searchInput } = await waitForInput();
 
-        const result = await readyEvent?.api.searchAndSelect("Dortmund");
+        const result = await readyEvent!.api.searchAndSelect("Dortmund");
 
         await waitFor(() => {
             expect(searchInput).toHaveValue("Dortmund");

--- a/src/packages/search/ui/Search.test.tsx
+++ b/src/packages/search/ui/Search.test.tsx
@@ -216,6 +216,27 @@ describe("search api", () => {
         await expect(waitForMenu(50)).rejects.toThrow("Menu not found");
         expect(selectHandler).toHaveBeenCalledTimes(1); // only Dortmund selection
     });
+
+    it("should search and select the first matching result when searchAndSelect is called", async () => {
+        let readyEvent: SearchReadyEvent | undefined;
+
+        await createSearch(undefined, undefined, (e: SearchReadyEvent) => {
+            readyEvent = e;
+        });
+
+        const { searchInput } = await waitForInput();
+
+        const result = await readyEvent?.api.searchAndSelect("Dortmund");
+
+        await waitFor(() => {
+            expect(searchInput).toHaveValue("Dortmund");
+        });
+
+        expect(result).toEqual({
+            id: 0,
+            label: "Dortmund"
+        });
+    });
 });
 
 async function createSearch(

--- a/src/packages/search/ui/Search.tsx
+++ b/src/packages/search/ui/Search.tsx
@@ -9,6 +9,7 @@ import {
     SearchClearEvent,
     SearchDisposedEvent,
     SearchReadyEvent,
+    SearchResult,
     SearchSelectEvent,
     SearchSource
 } from "../api";
@@ -81,15 +82,11 @@ export const Search: FC<SearchProps> = (props) => {
     } = props;
     const { containerProps } = useCommonComponentProps("search", props);
     const map = useMapModelValue(props);
-    const { input, results, onInputChanged, onOptionConfirmed, selectedOption } = useSearchState(
-        sources,
-        searchTypingDelay,
-        maxResultsPerGroup,
-        map
-    );
+    const { input, results, onInputChanged, onOptionConfirmed, selectedOption, searchAndSelect } =
+        useSearchState(sources, searchTypingDelay, maxResultsPerGroup, map);
 
     // api trigger hooks
-    useSearchApi(onReady, onDisposed, onInputChanged, onClear);
+    useSearchApi(onReady, onDisposed, onInputChanged, onClear, searchAndSelect);
 
     return (
         <Box {...containerProps} width={"100%"}>
@@ -112,7 +109,8 @@ function useSearchApi(
     onReady: ((event: SearchReadyEvent) => void) | undefined,
     onDisposed: ((event: SearchDisposedEvent) => void) | undefined,
     onInputChanged: (newValue: string) => void,
-    onClear: ((event: SearchClearEvent) => void) | undefined
+    onClear: ((event: SearchClearEvent) => void) | undefined,
+    searchAndSelect: (inputValue: string) => Promise<SearchResult | undefined>
 ) {
     const clearInput = useEvent(() => {
         onInputChanged("");
@@ -123,7 +121,7 @@ function useSearchApi(
     if (!apiRef.current) {
         // NOTE: The API object is only created once.
         // This is why the functions must currently be stable!
-        apiRef.current = new SearchApiImpl(clearInput, onInputChanged);
+        apiRef.current = new SearchApiImpl(clearInput, onInputChanged, searchAndSelect);
     }
 
     const api = apiRef.current;

--- a/src/packages/search/ui/Search.tsx
+++ b/src/packages/search/ui/Search.tsx
@@ -9,9 +9,9 @@ import {
     SearchClearEvent,
     SearchDisposedEvent,
     SearchReadyEvent,
-    SearchResult,
     SearchSelectEvent,
-    SearchSource
+    SearchSource,
+    SelectResult
 } from "../api";
 import { SearchApiImpl } from "./SearchApiImpl";
 import { SearchInput } from "./SearchInput";
@@ -45,12 +45,12 @@ export interface SearchProps extends CommonComponentProps, MapModelProps {
     placeholder?: string;
 
     /**
-     * This event handler will be called when the user selects a search result.
+     * This event handler will be called when a search result has been selected.
      */
     onSelect?: (event: SearchSelectEvent) => void;
 
     /**
-     * This event handler will be called when the user clears the search input.
+     * This event handler will be called when the search input has been cleared.
      */
     onClear?: (event: SearchClearEvent) => void;
 
@@ -83,7 +83,7 @@ export const Search: FC<SearchProps> = (props) => {
     const { containerProps } = useCommonComponentProps("search", props);
     const map = useMapModelValue(props);
     const { input, results, onInputChanged, onOptionConfirmed, selectedOption, searchAndSelect } =
-        useSearchState(sources, searchTypingDelay, maxResultsPerGroup, map);
+        useSearchState(sources, searchTypingDelay, maxResultsPerGroup, map, onSelect);
 
     // api trigger hooks
     useSearchApi(onReady, onDisposed, onInputChanged, onClear, searchAndSelect);
@@ -110,7 +110,7 @@ function useSearchApi(
     onDisposed: ((event: SearchDisposedEvent) => void) | undefined,
     onInputChanged: (newValue: string) => void,
     onClear: ((event: SearchClearEvent) => void) | undefined,
-    searchAndSelect: (inputValue: string) => Promise<SearchResult | undefined>
+    searchAndSelect: (inputValue: string) => Promise<SelectResult | undefined>
 ) {
     const clearInput = useEvent(() => {
         onInputChanged("");

--- a/src/packages/search/ui/SearchApiImpl.ts
+++ b/src/packages/search/ui/SearchApiImpl.ts
@@ -1,17 +1,20 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { SearchApi, SearchClearTrigger } from "../api";
+import { SearchApi, SearchClearTrigger, SearchResult } from "../api";
 
 export class SearchApiImpl implements SearchApi {
     #clearInput: (trigger: SearchClearTrigger) => void;
     #setInputValue: (newValue: string) => void;
+    #searchAndSelect: (input: string) => Promise<SearchResult | undefined>;
 
     constructor(
         clearInput: (trigger: SearchClearTrigger) => void,
-        setInputValue: (newValue: string) => void
+        setInputValue: (newValue: string) => void,
+        searchAndSelect: (inputValue: string) => Promise<SearchResult | undefined>
     ) {
         this.#clearInput = clearInput;
         this.#setInputValue = setInputValue;
+        this.#searchAndSelect = searchAndSelect;
     }
 
     resetInput() {
@@ -20,5 +23,9 @@ export class SearchApiImpl implements SearchApi {
 
     setInputValue(inputValue: string) {
         this.#setInputValue(inputValue);
+    }
+
+    async searchAndSelect(inputValue: string) {
+        return this.#searchAndSelect(inputValue);
     }
 }

--- a/src/packages/search/ui/SearchApiImpl.ts
+++ b/src/packages/search/ui/SearchApiImpl.ts
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { SearchApi, SearchClearTrigger, SearchResult } from "../api";
+import { SearchApi, SearchClearTrigger, SelectResult } from "../api";
 
 export class SearchApiImpl implements SearchApi {
     #clearInput: (trigger: SearchClearTrigger) => void;
     #setInputValue: (newValue: string) => void;
-    #searchAndSelect: (input: string) => Promise<SearchResult | undefined>;
+    #searchAndSelect: (input: string) => Promise<SelectResult | undefined>;
 
     constructor(
         clearInput: (trigger: SearchClearTrigger) => void,
         setInputValue: (newValue: string) => void,
-        searchAndSelect: (inputValue: string) => Promise<SearchResult | undefined>
+        searchAndSelect: (inputValue: string) => Promise<SelectResult | undefined>
     ) {
         this.#clearInput = clearInput;
         this.#setInputValue = setInputValue;

--- a/src/packages/search/ui/SearchInput.tsx
+++ b/src/packages/search/ui/SearchInput.tsx
@@ -192,7 +192,8 @@ function useSearchHandlers(
         onOptionConfirmed(selectedItem);
         onSelect?.({
             source: selectedItem.source,
-            result: selectedItem.result
+            result: selectedItem.result,
+            trigger: "user"
         });
     });
 

--- a/src/packages/search/ui/useSearchState.ts
+++ b/src/packages/search/ui/useSearchState.ts
@@ -4,9 +4,10 @@ import { createLogger, isAbortError } from "@open-pioneer/core";
 import { MapModel } from "@open-pioneer/map";
 import { useEvent } from "@open-pioneer/react-utils";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { SearchResult, SearchSource } from "../api";
+import { SearchResult, SearchSource, SelectResult } from "../api";
 import { sourceId } from "open-pioneer:source-info";
 import { SearchController, ResultGroup } from "../model/SearchController";
+import { SearchProps } from "./Search";
 
 const LOG = createLogger(sourceId);
 
@@ -47,7 +48,7 @@ export interface SearchState {
     onOptionConfirmed: (newOption: SearchOption) => void;
     onInputChanged: (newInput: string) => void;
 
-    searchAndSelect: (query: string) => Promise<SearchResult | undefined>;
+    searchAndSelect: (query: string) => Promise<SelectResult | undefined>;
 }
 
 export type SearchResultsReady = {
@@ -71,7 +72,8 @@ export function useSearchState(
     sources: SearchSource[],
     searchTypingDelay: number | undefined,
     maxResultsPerGroup: number | undefined,
-    map: MapModel
+    map: MapModel,
+    onSelect: SearchProps["onSelect"] | undefined // TODO: refactor --> model
 ): SearchState {
     interface FullSearchState {
         query: string;
@@ -162,37 +164,38 @@ export function useSearchState(
      * When a match is found, this function:
      * - Executes the search using the provided query.
      * - Updates the UI with the returned search results.
-     * - Selects the first available search option.
+     * - Selects the first available search option and notifies the component's callback function (if any).
      *
      * @param query - The search query to execute.
-     * @returns A promise that resolves to the selected {@link SearchResult},
+     * @returns A promise that resolves to the selected {@link SearchResult} and its source,
      * or `undefined` if no result is found or the search cannot be performed.
      */
-    const searchAndSelect = useEvent(async (query: string): Promise<SearchResult | undefined> => {
+    const searchAndSelect = useEvent(async (query: string): Promise<SelectResult | undefined> => {
         if (!controller) {
             return undefined;
         }
 
         const groups = await search(controller, query, getId);
-
-        const first = groups.flatMap((g) => g.options)[0];
-
-        if (!first) {
+        const firstOption = groups.flatMap((g) => g.options)[0];
+        if (!firstOption) {
             return undefined;
         }
+
+        const { result, source } = firstOption;
 
         // update UI
         dispatch({
             kind: "accept-results",
             results: groups
         });
-
         dispatch({
             kind: "select-option",
-            option: first
+            option: firstOption
         });
 
-        return first.result;
+        // notify component callback
+        onSelect?.({ result, source, trigger: "api-select" });
+        return { result, source };
     });
 
     // Called when the user confirms a search result

--- a/src/packages/search/ui/useSearchState.ts
+++ b/src/packages/search/ui/useSearchState.ts
@@ -46,6 +46,8 @@ export interface SearchState {
     // NOTE: Stable functions
     onOptionConfirmed: (newOption: SearchOption) => void;
     onInputChanged: (newInput: string) => void;
+
+    searchAndSelect: (query: string) => Promise<SearchResult | undefined>;
 }
 
 export type SearchResultsReady = {
@@ -151,6 +153,48 @@ export function useSearchState(
         ));
     });
 
+    /**
+     * Searches for the specified query and automatically selects the first matching result.
+     *
+     * If the search controller is unavailable or the search returns no results,
+     * the promise resolves to `undefined`.
+     *
+     * When a match is found, this function:
+     * - Executes the search using the provided query.
+     * - Updates the UI with the returned search results.
+     * - Selects the first available search option.
+     *
+     * @param query - The search query to execute.
+     * @returns A promise that resolves to the selected {@link SearchResult},
+     * or `undefined` if no result is found or the search cannot be performed.
+     */
+    const searchAndSelect = useEvent(async (query: string): Promise<SearchResult | undefined> => {
+        if (!controller) {
+            return undefined;
+        }
+
+        const groups = await search(controller, query, getId);
+
+        const first = groups.flatMap((g) => g.options)[0];
+
+        if (!first) {
+            return undefined;
+        }
+
+        // update UI
+        dispatch({
+            kind: "accept-results",
+            results: groups
+        });
+
+        dispatch({
+            kind: "select-option",
+            option: first
+        });
+
+        return first.result;
+    });
+
     // Called when the user confirms a search result
     const onOptionConfirmed = useEvent((option: SearchOption) => {
         // Do not start a new search when the user confirms a result
@@ -169,7 +213,8 @@ export function useSearchState(
         results: state.search,
         selectedOption: state.selectedOption,
         onOptionConfirmed,
-        onInputChanged
+        onInputChanged,
+        searchAndSelect
     };
 }
 

--- a/src/samples/test-search/search-app/AppUI.tsx
+++ b/src/samples/test-search/search-app/AppUI.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
+import { createLogger } from "@open-pioneer/core";
+import { sourceId } from "open-pioneer:source-info";
 import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react";
 import { DefaultMapProvider, MapAnchor, MapContainer, useMapModel } from "@open-pioneer/map";
 import { SectionHeading, TitledSection } from "@open-pioneer/react-utils";
@@ -9,6 +11,8 @@ import { Search, SearchApi, SearchClearEvent, SearchReadyEvent } from "@open-pio
 import { FakeCitySource } from "@open-pioneer/search/testSources";
 import { NotificationService, Notifier } from "@open-pioneer/notifier";
 import { useRef } from "react";
+
+const LOG = createLogger(sourceId);
 
 export function AppUI() {
     const intl = useIntl();
@@ -127,6 +131,25 @@ export function AppUI() {
                                             }}
                                         >
                                             set search input
+                                        </Button>
+                                        <Button
+                                            onClick={() => {
+                                                searchApiRef.current
+                                                    ?.searchAndSelect("Düsseldorf")
+                                                    .then((result) => {
+                                                        if (!result) {
+                                                            LOG.debug("No matching result found.");
+                                                            return;
+                                                        }
+
+                                                        onSearchSelect();
+                                                    })
+                                                    .catch((error) => {
+                                                        LOG.error(error);
+                                                    });
+                                            }}
+                                        >
+                                            set and selected search input
                                         </Button>
                                     </Flex>
                                 </MapAnchor>

--- a/src/samples/test-search/search-app/AppUI.tsx
+++ b/src/samples/test-search/search-app/AppUI.tsx
@@ -7,7 +7,14 @@ import { DefaultMapProvider, MapAnchor, MapContainer, useMapModel } from "@open-
 import { SectionHeading, TitledSection } from "@open-pioneer/react-utils";
 import { useIntl, useService } from "open-pioneer:react-hooks";
 import { MAP_ID } from "./MapConfigProviderImpl";
-import { Search, SearchApi, SearchClearEvent, SearchReadyEvent } from "@open-pioneer/search";
+import {
+    Search,
+    SearchApi,
+    SearchClearEvent,
+    SearchReadyEvent,
+    SearchResult,
+    SearchSelectEvent
+} from "@open-pioneer/search";
 import { FakeCitySource } from "@open-pioneer/search/testSources";
 import { NotificationService, Notifier } from "@open-pioneer/notifier";
 import { useRef } from "react";
@@ -22,12 +29,22 @@ export function AppUI() {
 
     const sources = [new FakeCitySource(1)];
 
-    function onSearchSelect() {
+    function onSearchSelect({ result }: SearchSelectEvent) {
         notificationService.notify({
             level: "info",
-            message: intl.formatMessage({ id: "selected" }),
+            message: intl.formatMessage({ id: "selected" }, { label: result.label }),
             displayDuration: 4000
         });
+    }
+
+    function onSelectViaApi(result: SearchResult) {
+        {
+            notificationService.notify({
+                level: "success",
+                message: intl.formatMessage({ id: "selectedViaApi" }, { label: result.label }),
+                displayDuration: 4000
+            });
+        }
     }
 
     function onSearchCleared(event: SearchClearEvent) {
@@ -136,13 +153,13 @@ export function AppUI() {
                                             onClick={() => {
                                                 searchApiRef.current
                                                     ?.searchAndSelect("Düsseldorf")
-                                                    .then((result) => {
-                                                        if (!result) {
+                                                    .then((selection) => {
+                                                        if (!selection) {
                                                             LOG.debug("No matching result found.");
                                                             return;
                                                         }
 
-                                                        onSearchSelect();
+                                                        onSelectViaApi(selection.result);
                                                     })
                                                     .catch((error) => {
                                                         LOG.error(error);

--- a/src/samples/test-search/search-app/i18n/de.yaml
+++ b/src/samples/test-search/search-app/i18n/de.yaml
@@ -1,5 +1,6 @@
 messages:
-  selected: "Eintrag ausgewählt"
+  selected: "Eintrag ausgewählt: {label}"
+  selectedViaApi: "Eintrag über API gefunden: {label}"
   cleared: "Zurückgesetzt"
   ariaLabel:
     header: "Kopfleiste"

--- a/src/samples/test-search/search-app/i18n/en.yaml
+++ b/src/samples/test-search/search-app/i18n/en.yaml
@@ -1,5 +1,6 @@
 messages:
-  selected: "selected entry"
+  selected: "selected entry: {label}"
+  selectedViaApi: "found entry via API: {label}"
   cleared: "cleared"
   ariaLabel:
     header: "Header bar"


### PR DESCRIPTION
Add `searchAndSelect` to the search API to allow programmatic searches. The method updates the search results shown in the UI and automatically selects the first matching result.

Returns the selected `SearchResult` when a match is found, or `undefined` when no matching result exists. Developers can use the returned result to access the selected feature, for example to zoom the map to the selected feature.