### PR TITLE
[Feature-Editing] Disable the select button when there are no visible layers

### DIFF
--- a/.changeset/busy-views-join.md
+++ b/.changeset/busy-views-join.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/feature-editing": minor
+---
+
+Disable the feature selection button when there are no visible layers for selection. The enabling / disabling behavior can be customized by using the new `getSelectionAvailability` prop.

--- a/src/packages/feature-editing/README.md
+++ b/src/packages/feature-editing/README.md
@@ -328,18 +328,19 @@ const featureWriter: FeatureWriter = {
 
 The `FeatureEditor` component accepts the following props:
 
-| Prop                             | Type                                     | Required | Description                                                                                                                     |
-| -------------------------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `map`                            | `MapModel`                               | No       | Map model to use (defaults to context map)                                                                                      |
-| `templates`                      | `FeatureTemplate[]`                      | Yes      | Feature templates defining the types of features that can be created or edited                                                  |
-| `writer`                         | `FeatureWriter`                          | Yes      | Storage implementation for feature create, update, and delete operations                                                        |
-| `selectableLayers`               | `Layer[]`                                | No       | Layers from which features can be selected. Defaults to layers matching template layer IDs                                      |
-| `snappableLayers`                | `Layer[]`                                | No       | Layers for snapping during drawing/modification. Defaults to `selectableLayers`                                                 |
-| `resolveFormTemplate`            | `(context) => FormTemplate \| undefined` | No       | Custom function to determine which form template to use when editing an existing feature (see below)                            |
-| `showActionBar`                  | `boolean`                                | No       | Whether to show undo/redo/finish/reset controls during drawing (default: `true`)                                                |
-| `successNotifierDisplayDuration` | `number \| false`                        | No       | Duration in ms to display success notifications. By default, never disappears. Use `false` to completely hide the notification. |
-| `failureNotifierDisplayDuration` | `number \| false`                        | No       | Duration in ms to display failure notifications. By default, never disappears. Use `false` to completely hide the notification. |
-| `onEditingStepChange`            | `(newEditingStep) => void`               | No       | Callback invoked when the editing workflow step changes                                                                         |
+| Prop                             | Type                                     | Required | Description                                                                                                                       |
+| -------------------------------- | ---------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `map`                            | `MapModel`                               | No       | Map model to use (defaults to context map)                                                                                        |
+| `templates`                      | `FeatureTemplate[]`                      | Yes      | Feature templates defining the types of features that can be created or edited                                                    |
+| `writer`                         | `FeatureWriter`                          | Yes      | Storage implementation for feature create, update, and delete operations                                                          |
+| `selectableLayers`               | `Layer[]`                                | No       | Layers from which features can be selected. Defaults to layers matching template layer IDs                                        |
+| `snappableLayers`                | `Layer[]`                                | No       | Layers for snapping during drawing/modification. Defaults to `selectableLayers`                                                   |
+| `getSelectionAvailability`       | `(context) => SelectionAvailability`     | No       | Custom function to enable or disable the selection interaction. By default: disabled when there are no visible selectable layers. |
+| `resolveFormTemplate`            | `(context) => FormTemplate \| undefined` | No       | Custom function to determine which form template to use when editing an existing feature (see below)                              |
+| `showActionBar`                  | `boolean`                                | No       | Whether to show undo/redo/finish/reset controls during drawing (default: `true`)                                                  |
+| `successNotifierDisplayDuration` | `number \| false`                        | No       | Duration in ms to display success notifications. By default, never disappears. Use `false` to completely hide the notification.   |
+| `failureNotifierDisplayDuration` | `number \| false`                        | No       | Duration in ms to display failure notifications. By default, never disappears. Use `false` to completely hide the notification.   |
+| `onEditingStepChange`            | `(newEditingStep) => void`               | No       | Callback invoked when the editing workflow step changes                                                                           |
 
 ### Interaction Options
 
@@ -354,6 +355,47 @@ The FeatureEditor also accepts OpenLayers interaction options for fine-grained c
 | `highlightingOptions` | `HighlightOptions`    | Options for feature highlighting   |
 
 The drawing options will be merged with those of the selected feature template (if any are given), with the ones of the template taking precedence.
+
+### Customizing the Availability of the Selection Interaction
+
+Editing an existing feature requires the user to select it on the map first.
+By default, the selection is only available if at least one of the selectable layers is visible; otherwise the selection button is disabled and a hint is shown to the user.
+
+Use the `getSelectionAvailability` prop to implement a different rule, for example if selection should also require a certain zoom level:
+
+```tsx
+import type {
+    SelectionAvailability,
+    SelectionAvailabilityContext
+} from "@open-pioneer/feature-editing";
+
+// Use a function that does not change its value on every render.
+const getSelectionAvailability = useCallback(
+    ({ mapModel, layers }: SelectionAvailabilityContext): SelectionAvailability => {
+        if (!layers.some((layer) => layer.visible)) {
+            return { status: "unavailable", reason: "Please activate an editable layer." };
+        }
+        if ((mapModel.zoomLevel ?? 0) < 12) {
+            return { status: "unavailable", reason: "Please zoom in to select a feature." };
+        }
+        return { status: "available" };
+    },
+    []
+);
+
+<FeatureEditor
+    templates={templates}
+    writer={featureWriter}
+    getSelectionAvailability={getSelectionAvailability}
+/>;
+```
+
+The `context` contains the `mapModel` and the `layers` that would be used for the selection interaction (i.e. `selectableLayers`, or the layers derived from the templates).
+The function is evaluated reactively: if it accesses reactive values (such as `layer.visible` or the map's zoom level),
+the availability is recomputed automatically when those values change.
+When `status` is `"unavailable"`, the optional `reason` is presented to the user.
+
+Use `useCallback` or any alternative measure to ensure that the function does not change too frequently.
 
 ### Resolving Form Templates
 

--- a/src/packages/feature-editing/api/editor/editor.ts
+++ b/src/packages/feature-editing/api/editor/editor.ts
@@ -10,6 +10,10 @@ import type { EditingStep } from "../model/EditingStep";
 import type { FeatureTemplate, FormTemplate } from "../model/FeatureTemplate";
 import type { FeatureWriter } from "../model/FeatureWriter";
 import type { InteractionOptions } from "../model/InteractionOptions";
+import {
+    SelectionAvailability,
+    SelectionAvailabilityContext
+} from "../model/SelectionAvailability";
 
 /**
  * React component that provides a complete editing interface for creating and modifying map
@@ -90,6 +94,21 @@ export interface FeatureEditorProps
      * @default selectableLayers
      */
     readonly snappableLayers?: Layer[];
+
+    /**
+     * A _reactive_ function that returns the selection interaction's availability state.
+     *
+     * The selection interaction is used by the editor to pick a feature from the map for editing.
+     *
+     * This function **SHOULD** be rather stable: you should use `useCallback` or equivalent mechanisms to avoid
+     * passing in a new function every time.
+     *
+     * Default: the selection interaction is available if there are any editable layers (as configured by {@link selectableLayers} or its default value)
+     * that are _visible_.
+     */
+    readonly getSelectionAvailability?: (
+        context: SelectionAvailabilityContext
+    ) => SelectionAvailability;
 
     /**
      * Whether to show the action bar with undo/redo/finish/reset controls during drawing.

--- a/src/packages/feature-editing/api/model/SelectionAvailability.ts
+++ b/src/packages/feature-editing/api/model/SelectionAvailability.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+
+import { Layer, MapModel } from "@open-pioneer/map";
+// oxlint-disable-next-line no-unused-vars
+import { type FeatureEditorProps } from "../editor/editor";
+
+/**
+ * The context made available to implementations of the {@link FeatureEditorProps.getSelectionAvailability | getSelectionAvailability} property.
+ *
+ * @group Model
+ */
+export interface SelectionAvailabilityContext {
+    /** The map used by the feature editor. */
+    mapModel: MapModel;
+
+    /** The layers the feature editor would use for the selection interaction. */
+    layers: Layer[];
+}
+
+/**
+ * The availability status for the selection button (available / unavailable).
+ *
+ * @group Model
+ */
+export type SelectionAvailability = SelectionAvailable | SelectionUnavailable;
+
+/**
+ * Selection is available.
+ *
+ * @group Model
+ */
+export interface SelectionAvailable {
+    status: "available";
+}
+
+/**
+ * Selection is unavailable.
+ *
+ * @group Model
+ */
+export interface SelectionUnavailable {
+    status: "unavailable";
+
+    /**
+     * The reason for being unavailable.
+     * This message will be presented to the user.
+     */
+    reason?: string;
+}

--- a/src/packages/feature-editing/i18n/de.yaml
+++ b/src/packages/feature-editing/i18n/de.yaml
@@ -8,6 +8,11 @@ messages:
     resetButtonTooltip: Zeichnung zurücksetzen
     undoButtonTooltip: Rückgängig machen
     redoButtonTooltip: Wiederholen
+
+  selection:
+    defaultNotAvailableMessage: "Es können keine Geoobjekte ausgewählt werden."
+    noVisibleLayers: "In der Karte sind derzeit keine editierbaren Layer sichtbar."
+
   propertyEditor:
     defaultEditHeading: Geoobjekt bearbeiten
     defaultCreateHeading: Geoobjekt erstellen
@@ -26,11 +31,13 @@ messages:
     message: Sind Sie sicher, dass Sie dieses Geoobjekt löschen möchten?
     deleteButtonTitle: Geoobjekt löschen
     cancelButtonTitle: Abbrechen
+
   cancelConfirmationDialog:
     title: Änderungen verwerfen
     message: Sind Sie sicher, dass Sie Ihre Änderungen verwerfen möchten?
     confirmCancelButtonTitle: Änderungen verwerfen
     abortCancelButtonTitle: Weiter bearbeiten
+
   notifier:
     creationSuccess: Geoobjekt erstellt
     creationFailure: Das Geoobjekt konnte nicht erstellt werden.
@@ -38,6 +45,7 @@ messages:
     updateFailure: Das Geoobjekt konnte nicht aktualisiert werden.
     deletionSuccess: Geoobjekt gelöscht
     deletionFailure: Das Geoobjekt konnte nicht gelöscht werden.
+
   tooltips:
     drawingMessagePoint: Klicken Sie in die Karte, um den Punkt zu zeichnen.
     drawingMessageLineString: Klicken, um mit dem Zeichnen zu beginnen. <br></br> Doppelklicken, um die Zeichnung zu beenden.

--- a/src/packages/feature-editing/i18n/en.yaml
+++ b/src/packages/feature-editing/i18n/en.yaml
@@ -8,6 +8,11 @@ messages:
     resetButtonTooltip: Reset drawing
     undoButtonTooltip: Undo
     redoButtonTooltip: Redo
+
+  selection:
+    defaultNotAvailableMessage: "No features can be selected."
+    noVisibleLayers: "No editable layers are visible in the map."
+
   propertyEditor:
     defaultEditHeading: Edit Feature
     defaultCreateHeading: Create Feature
@@ -26,11 +31,13 @@ messages:
     message: Are you sure you want to delete this feature?
     deleteButtonTitle: Delete feature
     cancelButtonTitle: Cancel
+
   cancelConfirmationDialog:
     title: Discard changes
     message: Are you sure you want to discard your changes?
     confirmCancelButtonTitle: Discard changes
     abortCancelButtonTitle: Continue editing
+
   notifier:
     creationSuccess: Feature created
     creationFailure: The feature failed to be created.
@@ -38,6 +45,7 @@ messages:
     updateFailure: The feature failed to be updated.
     deletionSuccess: Feature deleted
     deletionFailure: The feature failed to be deleted.
+
   tooltips:
     drawingMessagePoint: Click on the map to draw the point.
     drawingMessageLineString: Click to start drawing. Double-click to finish drawing.

--- a/src/packages/feature-editing/implementation/FeatureEditor.test.tsx
+++ b/src/packages/feature-editing/implementation/FeatureEditor.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 
+import { reactive } from "@conterra/reactivity-core";
 import { LayerFactory } from "@open-pioneer/map";
 import { createTestLayer, createTestOlLayer, setupMap } from "@open-pioneer/map-test-utils";
 import type { NotificationService } from "@open-pioneer/notifier";
@@ -204,6 +205,7 @@ describe("Editor interaction", () => {
     });
 
     it("disables the select button when there are no selectable layers", async () => {
+        const user = userEvent.setup();
         const { map, layerFactory } = await setupMap();
         const onEditingStepChange = vi.fn();
 
@@ -224,6 +226,15 @@ describe("Editor interaction", () => {
 
         // No layers -> disabled
         expect(selectButton).toBeDisabled();
+
+        // The tooltip explains why the button is disabled.
+        await user.hover(selectButton);
+        await waitFor(
+            () => {
+                expect(selectButton).toHaveAccessibleDescription("selection.noVisibleLayers");
+            },
+            { timeout: 3000 }
+        );
     });
 
     it("disables the select button when all layers are invisible", async () => {
@@ -265,6 +276,48 @@ describe("Editor interaction", () => {
         layers[0]!.setVisible(true);
         await waitFor(() => {
             expect(selectButton).toBeEnabled();
+        });
+    });
+
+    it("supports custom strategies for the availability of the selection interaction", async () => {
+        const user = userEvent.setup();
+        const { map, layerFactory } = await setupMap();
+        const onEditingStepChange = vi.fn();
+
+        // Simple signal to test reactivity
+        const errorMessage = reactive("");
+
+        render(
+            <PackageContextProvider services={createInjectedServices(layerFactory)}>
+                <FeatureEditor
+                    map={map}
+                    templates={allTemplates}
+                    writer={mockWriter}
+                    onEditingStepChange={onEditingStepChange}
+                    getSelectionAvailability={() => {
+                        return errorMessage.value
+                            ? { status: "unavailable", reason: errorMessage.value }
+                            : { status: "available" };
+                    }}
+                />
+            </PackageContextProvider>
+        );
+
+        const selectButton = await screen.findByRole("button", {
+            name: /actionSelector\.selectButtonTitle/i
+        });
+        expect(selectButton).toBeEnabled();
+
+        // The editor watches on the function above, which uses this signal.
+        errorMessage.value = "Something went wrong!";
+        await waitFor(() => {
+            expect(selectButton).toBeDisabled();
+        });
+
+        // The tooltip carries the reason from above.
+        await user.hover(selectButton);
+        await waitFor(() => {
+            expect(selectButton).toHaveAccessibleDescription(errorMessage.value);
         });
     });
 });

--- a/src/packages/feature-editing/implementation/FeatureEditor.test.tsx
+++ b/src/packages/feature-editing/implementation/FeatureEditor.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LayerFactory } from "@open-pioneer/map";
-import { setupMap } from "@open-pioneer/map-test-utils";
+import { createTestLayer, createTestOlLayer, setupMap } from "@open-pioneer/map-test-utils";
 import type { NotificationService } from "@open-pioneer/notifier";
 import { PackageContextProvider } from "@open-pioneer/test-utils/react";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -127,6 +127,7 @@ describe("Editor interaction", () => {
     it("changes editing step when clicking the select button", async () => {
         const user = userEvent.setup();
         const { map, layerFactory } = await setupMap();
+        const layer = createTestLayer();
         const onEditingStepChange = vi.fn();
 
         render(
@@ -135,6 +136,8 @@ describe("Editor interaction", () => {
                     map={map}
                     templates={allTemplates}
                     writer={mockWriter}
+                    // Needs at least one layer to enable the button
+                    selectableLayers={[layer]}
                     onEditingStepChange={onEditingStepChange}
                 />
             </PackageContextProvider>
@@ -158,6 +161,8 @@ describe("Editor interaction", () => {
     it("toggles select button state when clicked", async () => {
         const user = userEvent.setup();
         const { map, layerFactory } = await setupMap();
+        const layer = createTestLayer();
+
         const onEditingStepChange = vi.fn();
 
         render(
@@ -166,6 +171,8 @@ describe("Editor interaction", () => {
                     map={map}
                     templates={allTemplates}
                     writer={mockWriter}
+                    // Needs at least one layer to enable the button
+                    selectableLayers={[layer]}
                     onEditingStepChange={onEditingStepChange}
                 />
             </PackageContextProvider>
@@ -193,6 +200,71 @@ describe("Editor interaction", () => {
             const calls = onEditingStepChange.mock.calls;
             const lastCall = calls[calls.length - 1]?.[0];
             expect(lastCall).toEqual({ id: "initial" });
+        });
+    });
+
+    it("disables the select button when there are no selectable layers", async () => {
+        const { map, layerFactory } = await setupMap();
+        const onEditingStepChange = vi.fn();
+
+        render(
+            <PackageContextProvider services={createInjectedServices(layerFactory)}>
+                <FeatureEditor
+                    map={map}
+                    templates={allTemplates}
+                    writer={mockWriter}
+                    onEditingStepChange={onEditingStepChange}
+                />
+            </PackageContextProvider>
+        );
+
+        const selectButton = await screen.findByRole("button", {
+            name: /actionSelector\.selectButtonTitle/i
+        });
+
+        // No layers -> disabled
+        expect(selectButton).toBeDisabled();
+    });
+
+    it("disables the select button when all layers are invisible", async () => {
+        const { map, layerFactory } = await setupMap();
+        const layers = [
+            createTestLayer({
+                title: "A",
+                olLayer: createTestOlLayer(),
+                visible: false
+            }),
+            createTestLayer({
+                title: "B",
+                olLayer: createTestOlLayer(),
+                visible: false
+            })
+        ];
+        const onEditingStepChange = vi.fn();
+
+        render(
+            <PackageContextProvider services={createInjectedServices(layerFactory)}>
+                <FeatureEditor
+                    map={map}
+                    templates={allTemplates}
+                    writer={mockWriter}
+                    selectableLayers={layers}
+                    onEditingStepChange={onEditingStepChange}
+                />
+            </PackageContextProvider>
+        );
+
+        const selectButton = await screen.findByRole("button", {
+            name: /actionSelector\.selectButtonTitle/i
+        });
+
+        // All layers hidden -> disabled
+        expect(selectButton).toBeDisabled();
+
+        // Enabled again when at least one layer is visible
+        layers[0]!.setVisible(true);
+        await waitFor(() => {
+            expect(selectButton).toBeEnabled();
         });
     });
 });

--- a/src/packages/feature-editing/implementation/FeatureEditor.tsx
+++ b/src/packages/feature-editing/implementation/FeatureEditor.tsx
@@ -23,6 +23,7 @@ export function FeatureEditor(props: FeatureEditorProps): ReactElement {
         resolveFormTemplate,
         selectableLayers,
         snappableLayers = selectableLayers,
+        getSelectionAvailability,
         showActionBar = true,
         successNotifierDisplayDuration,
         failureNotifierDisplayDuration,
@@ -91,6 +92,7 @@ export function FeatureEditor(props: FeatureEditorProps): ReactElement {
                     mapModel={mapModel}
                     templates={templates}
                     selectableLayers={selectableLayers}
+                    getSelectionAvailability={getSelectionAvailability}
                     showActionBar={showActionBar}
                     onActionChange={onActionChange}
                     drawingState={drawingState}

--- a/src/packages/feature-editing/implementation/FeatureEditor.tsx
+++ b/src/packages/feature-editing/implementation/FeatureEditor.tsx
@@ -87,7 +87,10 @@ export function FeatureEditor(props: FeatureEditorProps): ReactElement {
         case "selection":
             content = (
                 <ActionSelector
+                    editingStep={editingStep}
+                    mapModel={mapModel}
                     templates={templates}
+                    selectableLayers={selectableLayers}
                     showActionBar={showActionBar}
                     onActionChange={onActionChange}
                     drawingState={drawingState}

--- a/src/packages/feature-editing/implementation/components/action-selector/ActionSelector.tsx
+++ b/src/packages/feature-editing/implementation/components/action-selector/ActionSelector.tsx
@@ -7,6 +7,7 @@ import { TitledSection, useEvent } from "@open-pioneer/react-utils";
 import type { Type as GeometryType } from "ol/geom/Geometry";
 import { useIntl } from "open-pioneer:react-hooks";
 import { useEffect, useEffectEvent, useMemo, useState, type ReactElement } from "react";
+import { FeatureEditorProps } from "../../../api/editor/editor";
 import { EditingStep } from "../../../api/model/EditingStep";
 import type { FeatureTemplate } from "../../../api/model/FeatureTemplate";
 import { useSelectionAvailability } from "../../editor/editorHooks";
@@ -17,13 +18,14 @@ import { TemplateSelector } from "./TemplateSelector";
 
 // TODO(refactor): Takes too many props, just to show or reset the availability of the select button.
 export interface ActionSelectorProps {
-    readonly mapModel: MapModel;
-    readonly selectableLayers: Layer[] | undefined;
-    readonly templates: FeatureTemplate[];
-    readonly showActionBar: boolean;
-    readonly editingStep: EditingStep;
-    readonly drawingState: DrawingState;
-    readonly onActionChange: (newAction: Action | undefined) => void;
+    mapModel: MapModel;
+    templates: FeatureTemplate[];
+    selectableLayers: Layer[] | undefined;
+    getSelectionAvailability: FeatureEditorProps["getSelectionAvailability"];
+    showActionBar: boolean;
+    editingStep: EditingStep;
+    drawingState: DrawingState;
+    onActionChange: (newAction: Action | undefined) => void;
 }
 
 export interface CreateAction {
@@ -39,14 +41,20 @@ export type Action = CreateAction | UpdateAction;
 
 export function ActionSelector({
     mapModel,
-    selectableLayers,
     templates,
+    selectableLayers,
+    getSelectionAvailability,
     showActionBar,
     editingStep,
     drawingState,
     onActionChange
 }: ActionSelectorProps): ReactElement {
-    const selectionAvailability = useSelectionAvailability(mapModel, templates, selectableLayers);
+    const selectionAvailability = useSelectionAvailability(
+        mapModel,
+        templates,
+        selectableLayers,
+        getSelectionAvailability
+    );
 
     // Reset editing step "initial" when the selection becomes unavailable.
     // TODO(refactor): this should be initiated by the model; not the UI.

--- a/src/packages/feature-editing/implementation/components/action-selector/ActionSelector.tsx
+++ b/src/packages/feature-editing/implementation/components/action-selector/ActionSelector.tsx
@@ -2,19 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Flex } from "@chakra-ui/react";
+import { Layer, MapModel } from "@open-pioneer/map";
 import { TitledSection, useEvent } from "@open-pioneer/react-utils";
 import type { Type as GeometryType } from "ol/geom/Geometry";
 import { useIntl } from "open-pioneer:react-hooks";
-import { useMemo, useState, type ReactElement } from "react";
+import { useEffect, useEffectEvent, useMemo, useState, type ReactElement } from "react";
+import { EditingStep } from "../../../api/model/EditingStep";
 import type { FeatureTemplate } from "../../../api/model/FeatureTemplate";
+import { useSelectionAvailability } from "../../editor/editorHooks";
 import { DrawingState } from "../../geometry-editing/useGeometryEditing";
 import { DrawingControls } from "./DrawingControls";
 import { SelectButton } from "./SelectButton";
 import { TemplateSelector } from "./TemplateSelector";
 
+// TODO(refactor): Takes too many props, just to show or reset the availability of the select button.
 export interface ActionSelectorProps {
+    readonly mapModel: MapModel;
+    readonly selectableLayers: Layer[] | undefined;
     readonly templates: FeatureTemplate[];
     readonly showActionBar: boolean;
+    readonly editingStep: EditingStep;
     readonly drawingState: DrawingState;
     readonly onActionChange: (newAction: Action | undefined) => void;
 }
@@ -31,11 +38,25 @@ export interface UpdateAction {
 export type Action = CreateAction | UpdateAction;
 
 export function ActionSelector({
+    mapModel,
+    selectableLayers,
     templates,
     showActionBar,
+    editingStep,
     drawingState,
     onActionChange
 }: ActionSelectorProps): ReactElement {
+    const selectionAvailability = useSelectionAvailability(mapModel, templates, selectableLayers);
+
+    // Reset editing step "initial" when the selection becomes unavailable.
+    // TODO(refactor): this should be initiated by the model; not the UI.
+    const onActionChangeEffect = useEffectEvent(onActionChange);
+    useEffect(() => {
+        if (editingStep.id === "selection" && selectionAvailability.status === "unavailable") {
+            onActionChangeEffect(undefined);
+        }
+    }, [editingStep.id, selectionAvailability.status]);
+
     const [selectButtonIsActive, setSelectButtonActive] = useState(false);
     const [selectedTemplate, setSelectedTemplate] = useState<FeatureTemplate>();
 
@@ -71,7 +92,16 @@ export function ActionSelector({
             overflowY="auto"
         >
             <TitledSection title={editFeatureHeading} sectionHeadingProps={{ size: "sm" }}>
-                <SelectButton isActive={selectButtonIsActive} onClick={onButtonClick} />
+                <SelectButton
+                    isAvailable={selectionAvailability.status === "available"}
+                    notAvailableMessage={
+                        selectionAvailability.status === "unavailable"
+                            ? selectionAvailability.reason
+                            : undefined
+                    }
+                    isActive={selectButtonIsActive}
+                    onClick={onButtonClick}
+                />
             </TitledSection>
 
             <TitledSection title={createFeatureHeading} sectionHeadingProps={{ size: "sm", mt: 3 }}>

--- a/src/packages/feature-editing/implementation/components/action-selector/SelectButton.tsx
+++ b/src/packages/feature-editing/implementation/components/action-selector/SelectButton.tsx
@@ -4,7 +4,7 @@
 import { Button, Toggle } from "@chakra-ui/react";
 import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
 import { useIntl } from "open-pioneer:react-hooks";
-import { useEffect, useMemo, type ReactElement } from "react";
+import { useMemo, type ReactElement } from "react";
 import { LuMousePointerClick } from "react-icons/lu";
 
 interface SelectButtonProps {
@@ -35,14 +35,6 @@ export function SelectButton(props: SelectButtonProps): ReactElement {
             intl.formatMessage({ id: "selection.defaultNotAvailableMessage" })
         );
     }, [intl, isAvailable, notAvailableMessageProp]);
-
-    useEffect(() => {
-        if (notAvailableMessage != null) {
-            console.log("Not available", notAvailableMessage);
-        } else {
-            console.log("Available");
-        }
-    }, [notAvailableMessage]);
 
     return (
         <Tooltip disabled={notAvailableMessage == null} content={notAvailableMessage}>

--- a/src/packages/feature-editing/implementation/components/action-selector/SelectButton.tsx
+++ b/src/packages/feature-editing/implementation/components/action-selector/SelectButton.tsx
@@ -2,34 +2,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button, Toggle } from "@chakra-ui/react";
+import { Tooltip } from "@open-pioneer/chakra-snippets/tooltip";
 import { useIntl } from "open-pioneer:react-hooks";
-import type { ReactElement } from "react";
+import { useEffect, useMemo, type ReactElement } from "react";
 import { LuMousePointerClick } from "react-icons/lu";
 
 interface SelectButtonProps {
-    readonly isActive: boolean;
-    readonly onClick: () => void;
+    isAvailable: boolean;
+    notAvailableMessage: string | undefined;
+
+    isActive: boolean;
+    onClick: () => void;
 }
 
-export function SelectButton({ isActive, onClick }: SelectButtonProps): ReactElement {
-    const { formatMessage } = useIntl();
+export function SelectButton(props: SelectButtonProps): ReactElement {
+    const {
+        isAvailable,
+        notAvailableMessage: notAvailableMessageProp,
+        isActive: isActiveProp,
+        onClick
+    } = props;
+    const intl = useIntl();
+
+    const isActive = isAvailable && isActiveProp;
+
+    const notAvailableMessage = useMemo(() => {
+        if (isAvailable) {
+            return undefined;
+        }
+        return (
+            notAvailableMessageProp ??
+            intl.formatMessage({ id: "selection.defaultNotAvailableMessage" })
+        );
+    }, [intl, isAvailable, notAvailableMessageProp]);
+
+    useEffect(() => {
+        if (notAvailableMessage != null) {
+            console.log("Not available", notAvailableMessage);
+        } else {
+            console.log("Available");
+        }
+    }, [notAvailableMessage]);
 
     return (
-        <Toggle.Root pressed={isActive} asChild>
-            <Button
-                className="editor__action-selector-select-button"
-                variant="outline"
-                _hover={{ bg: isActive ? "colorPalette.700" : "colorPalette.subtle" }}
-                _pressed={{ bg: "colorPalette.800", color: "colorPalette.contrast" }}
-                // Margin for focus outline
-                marginX="4px"
-                onClick={onClick}
-            >
-                <LuMousePointerClick aria-hidden="true" />
-                {isActive
-                    ? formatMessage({ id: "actionSelector.selectButtonActiveTitle" })
-                    : formatMessage({ id: "actionSelector.selectButtonTitle" })}
-            </Button>
-        </Toggle.Root>
+        <Tooltip disabled={notAvailableMessage == null} content={notAvailableMessage}>
+            <Toggle.Root disabled={!isAvailable} pressed={isActive} asChild>
+                <Button
+                    className="editor__action-selector-select-button"
+                    variant="outline"
+                    _hover={{ bg: isActive ? "colorPalette.700" : "colorPalette.subtle" }}
+                    _pressed={{ bg: "colorPalette.800", color: "colorPalette.contrast" }}
+                    // Margin for focus outline
+                    marginX="4px"
+                    onClick={onClick}
+                >
+                    <LuMousePointerClick aria-hidden="true" />
+                    {isActive
+                        ? intl.formatMessage({ id: "actionSelector.selectButtonActiveTitle" })
+                        : intl.formatMessage({ id: "actionSelector.selectButtonTitle" })}
+                </Button>
+            </Toggle.Root>
+        </Tooltip>
     );
 }

--- a/src/packages/feature-editing/implementation/editor/editorHooks.ts
+++ b/src/packages/feature-editing/implementation/editor/editorHooks.ts
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2023-2025 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 
+import { createLogger } from "@open-pioneer/core";
 import { isLayer, type Layer, type MapModel } from "@open-pioneer/map";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
 import { Vector as VectorLayer } from "ol/layer";
 import type { Vector as VectorSource } from "ol/source";
+import { useIntl } from "open-pioneer:react-hooks";
+import { sourceId } from "open-pioneer:source-info";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
     DrawingStep,
@@ -15,7 +18,14 @@ import type {
 import type { FeatureTemplate } from "../../api/model/FeatureTemplate";
 import type { Action } from "../components/action-selector/ActionSelector";
 
+const LOG = createLogger(sourceId);
+
 type StatePair<S> = [S, (newState: S) => void];
+
+// TODO(refactor): The logic in this file would really profit from a shared (reactive) model.
+// It would make it easier to understand, but would also improve the performance.
+// For example, the `defaultLayers` are evaluated multiple times (each call site),
+// but always resolve to the same values.
 
 export function useEditingStep(
     onEditingStepChange: ((newStep: EditingStep) => void) | undefined
@@ -23,6 +33,7 @@ export function useEditingStep(
     const [editingStep, setEditingStep] = useState<EditingStep>({ id: "initial" });
 
     useEffect(() => {
+        LOG.debug("Editing step changed to", editingStep);
         onEditingStepChange?.(editingStep);
     }, [editingStep, onEditingStepChange]);
 
@@ -54,6 +65,41 @@ export function useOnActionChange(
     );
 }
 
+export type SelectionAvailability = SelectionAvailable | SelectionUnavailable;
+
+export interface SelectionAvailable {
+    status: "available";
+}
+
+export interface SelectionUnavailable {
+    status: "unavailable";
+    reason?: string;
+}
+
+/**
+ * Evaluates whether the 'select' interaction should be available in the user interface.
+ */
+export function useSelectionAvailability(
+    mapModel: MapModel,
+    templates: FeatureTemplate[],
+    selectableLayers: Layer[] | undefined,
+    customStrategy?: undefined
+): SelectionAvailability {
+    const intl = useIntl();
+    const defaultLayers = useDefaultLayers(mapModel, templates);
+    const layers = selectableLayers ?? defaultLayers;
+    const isAvailable = useReactiveSnapshot(() => layers.some((layer) => layer.visible), [layers]);
+    if (!isAvailable) {
+        return {
+            status: "unavailable",
+            reason: intl.formatMessage({ id: "selection.noVisibleLayers" })
+        };
+    }
+    return {
+        status: "available"
+    };
+}
+
 export function useSnappingSources(
     mapModel: MapModel | undefined,
     snappableLayers: Layer[] | undefined,
@@ -62,7 +108,7 @@ export function useSnappingSources(
     const defaultLayers = useDefaultLayers(mapModel, templates);
 
     return useMemo(() => {
-        return compactMap(snappableLayers ?? defaultLayers, (layer) =>
+        return filterMap(snappableLayers ?? defaultLayers, (layer) =>
             layer.olLayer instanceof VectorLayer ? layer.olLayer.getSource() : undefined
         );
     }, [defaultLayers, snappableLayers]);
@@ -70,14 +116,14 @@ export function useSnappingSources(
 
 function useDefaultLayers(mapModel: MapModel | undefined, templates: FeatureTemplate[]): Layer[] {
     return useReactiveSnapshot(() => {
-        const layerIds = compactMap(templates, ({ layerId }) => layerId);
+        const layerIds = filterMap(templates, ({ layerId }) => layerId);
         const uniqueLayerIds = new Set(layerIds);
-        const layers = compactMap([...uniqueLayerIds], (id) => mapModel?.layers.getLayerById(id));
+        const layers = filterMap([...uniqueLayerIds], (id) => mapModel?.layers.getLayerById(id));
         return layers.filter((layer) => isLayer(layer));
     }, [mapModel, templates]);
 }
 
-function compactMap<T, U>(array: T[], mapper: (element: T) => U | undefined): U[] {
+function filterMap<T, U>(array: T[], mapper: (element: T) => U | undefined): U[] {
     return array.flatMap((element) => {
         const value = mapper(element);
         return value != null ? [value] : [];

--- a/src/packages/feature-editing/implementation/editor/editorHooks.ts
+++ b/src/packages/feature-editing/implementation/editor/editorHooks.ts
@@ -9,6 +9,7 @@ import type { Vector as VectorSource } from "ol/source";
 import { useIntl } from "open-pioneer:react-hooks";
 import { sourceId } from "open-pioneer:source-info";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { FeatureEditorProps } from "../../api/editor/editor";
 import type {
     DrawingStep,
     EditingStep,
@@ -16,6 +17,10 @@ import type {
     SelectionStep
 } from "../../api/model/EditingStep";
 import type { FeatureTemplate } from "../../api/model/FeatureTemplate";
+import {
+    SelectionAvailability,
+    SelectionAvailabilityContext
+} from "../../api/model/SelectionAvailability";
 import type { Action } from "../components/action-selector/ActionSelector";
 
 const LOG = createLogger(sourceId);
@@ -65,17 +70,6 @@ export function useOnActionChange(
     );
 }
 
-export type SelectionAvailability = SelectionAvailable | SelectionUnavailable;
-
-export interface SelectionAvailable {
-    status: "available";
-}
-
-export interface SelectionUnavailable {
-    status: "unavailable";
-    reason?: string;
-}
-
 /**
  * Evaluates whether the 'select' interaction should be available in the user interface.
  */
@@ -83,21 +77,38 @@ export function useSelectionAvailability(
     mapModel: MapModel,
     templates: FeatureTemplate[],
     selectableLayers: Layer[] | undefined,
-    customStrategy?: undefined
+    getCustomSelectionAvailability?: FeatureEditorProps["getSelectionAvailability"]
 ): SelectionAvailability {
     const intl = useIntl();
     const defaultLayers = useDefaultLayers(mapModel, templates);
     const layers = selectableLayers ?? defaultLayers;
-    const isAvailable = useReactiveSnapshot(() => layers.some((layer) => layer.visible), [layers]);
-    if (!isAvailable) {
-        return {
-            status: "unavailable",
-            reason: intl.formatMessage({ id: "selection.noVisibleLayers" })
-        };
-    }
-    return {
-        status: "available"
-    };
+
+    // Reactive function, useCallback is used for stability. See useReactiveSnapshot below,
+    // the function is a dependency of the snapshot, too.
+    const getDefaultSelectionAvailability = useCallback(
+        ({ layers }: SelectionAvailabilityContext): SelectionAvailability => {
+            const isAvailable = layers.some((layer) => layer.visible);
+            if (!isAvailable) {
+                return {
+                    status: "unavailable",
+                    reason: intl.formatMessage({ id: "selection.noVisibleLayers" })
+                };
+            }
+            return {
+                status: "available"
+            };
+        },
+        [intl]
+    );
+    const getAvailability = getCustomSelectionAvailability ?? getDefaultSelectionAvailability;
+
+    // Watches the function's result using the reactivity API.
+    // TODO(refactor): this is extremely awkward because _most_ data in this package lives in the react layer.
+    // Ideally, both the `layers` and the selection availability strategy would live purely in the model,
+    // and we would not have to dance around with hooks and watches.
+    return useReactiveSnapshot(() => {
+        return getAvailability({ mapModel, layers });
+    }, [mapModel, layers, getAvailability]);
 }
 
 export function useSnappingSources(

--- a/src/packages/feature-editing/index.ts
+++ b/src/packages/feature-editing/index.ts
@@ -65,6 +65,13 @@ export type {
     SnappingOptions
 } from "./api/model/InteractionOptions";
 
+export type {
+    SelectionAvailability,
+    SelectionAvailabilityContext,
+    SelectionAvailable,
+    SelectionUnavailable
+} from "./api/model/SelectionAvailability";
+
 // =================================================================
 // Field configurations
 // =================================================================

--- a/src/packages/map-test-utils/index.ts
+++ b/src/packages/map-test-utils/index.ts
@@ -225,7 +225,20 @@ export function createTestLayer<LayerType extends Layer, Config extends MapPacka
     mapOptions?: Pick<SimpleMapOptions, "fetch">
 ): LayerType;
 
-/** Creates a new, basic SimpleLayer for testing. */
+/**
+ *
+ * Creates a new, basic SimpleLayer for testing.
+ *
+ * For example:
+ *
+ * ```ts
+ * const layer1 = createTestLayer();
+ * const layer2 = createTestLayer({
+ *   title: "My test layer",
+ *   olLayer: ...
+ * })
+ * ```
+ **/
 export function createTestLayer(
     config?: SimpleLayerConfig,
     mapOptions?: Pick<SimpleMapOptions, "fetch">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
     const devMode = mode === "development";
 
     // Allowed values are "DEBUG", "INFO", "WARN", "ERROR"
-    const logLevel = devMode ? "INFO" : "WARN";
+    const logLevel = devMode ? "DEBUG" : "WARN";
 
     return {
         root: resolve(__dirname, "src"),


### PR DESCRIPTION
- Disable the selection button when there are no selectable layers or all of them are invisible
- Support new prop `getSelectionAvailability` to override this with a custom strategy

See #671 