### PR TITLE
[Feature-Editing] Don't show the cancel dialog when the feature was not modified

### DIFF
--- a/.changeset/tired-camels-beg.md
+++ b/.changeset/tired-camels-beg.md
@@ -1,0 +1,5 @@
+---
+"@open-pioneer/feature-editing": minor
+---
+
+When editing an existing feature: do not show the "confirm cancel" dialog when the feature wasn't actually modifified.

--- a/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.test.tsx
+++ b/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.test.tsx
@@ -134,7 +134,7 @@ describe("create mode workflow", () => {
         expect(onSave).toHaveBeenCalledOnce();
     });
 
-    it("shows cancel confirmation dialog before canceling and allows canceling without saving", async () => {
+    it("shows cancel confirmation dialog before canceling and allows canceling without saving for create operations", async () => {
         const user = userEvent.setup();
         const template = createTemplate();
         const feature = new Feature();
@@ -167,6 +167,100 @@ describe("create mode workflow", () => {
 
         expect(onCancel).toHaveBeenCalledOnce();
         expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("does not show the cancel dialog when the feature has not been edited for update operations", async () => {
+        const user = userEvent.setup();
+        const feature = new Feature();
+        feature.setGeometry(new Point([0, 0]));
+
+        const step: ModificationStep = {
+            id: "update",
+            feature,
+            layer: {} as any
+        };
+        const onSave = vi.fn();
+        const onCancel = vi.fn();
+        renderEditor({
+            step,
+            resolveFormTemplate: () => createTemplate(),
+            callbacks: { onSave, onCancel }
+        });
+
+        const cancelButton = await screen.findByRole("button", { name: /cancelButtonTitle/i });
+        await user.click(cancelButton);
+
+        // No dialog: the feature was never modified.
+        await waitFor(() => {
+            expect(onCancel).toHaveBeenCalled();
+        });
+    });
+
+    it("shows the cancel dialog when a property has been edited for update operations", async () => {
+        const user = userEvent.setup();
+        const feature = new Feature();
+        feature.setGeometry(new Point([0, 0]));
+
+        const step: ModificationStep = {
+            id: "update",
+            feature,
+            layer: {} as any
+        };
+        const onSave = vi.fn();
+        const onCancel = vi.fn();
+        renderEditor({
+            step,
+            resolveFormTemplate: () => createTemplate(),
+            callbacks: { onSave, onCancel }
+        });
+
+        // Update name
+        const nameInput = screen.getByLabelText(/name/i);
+        await user.clear(nameInput);
+        await user.type(nameInput, "Updated Name");
+
+        const cancelButton = await screen.findByRole("button", { name: /cancelButtonTitle/i });
+        await user.click(cancelButton);
+
+        // Cancel shows the dialog now
+        expect(onCancel).not.toHaveBeenCalled();
+        const confirmCancelButton = await screen.findByRole("button", {
+            name: /confirmCancelButtonTitle/i
+        });
+        expect(confirmCancelButton).toBeInTheDocument();
+    });
+
+    it("shows the cancel dialog when the geometry has been edited for update operations", async () => {
+        const user = userEvent.setup();
+        const feature = new Feature();
+        const point = new Point([0, 0]);
+        feature.setGeometry(point);
+
+        const step: ModificationStep = {
+            id: "update",
+            feature,
+            layer: {} as any
+        };
+        const onSave = vi.fn();
+        const onCancel = vi.fn();
+        renderEditor({
+            step,
+            resolveFormTemplate: () => createTemplate(),
+            callbacks: { onSave, onCancel }
+        });
+
+        // Simulate geometry edit
+        point.setCoordinates([1, 2]);
+
+        const cancelButton = await screen.findByRole("button", { name: /cancelButtonTitle/i });
+        await user.click(cancelButton);
+
+        // Cancel shows the dialog now
+        expect(onCancel).not.toHaveBeenCalled();
+        const confirmCancelButton = await screen.findByRole("button", {
+            name: /confirmCancelButtonTitle/i
+        });
+        expect(confirmCancelButton).toBeInTheDocument();
     });
 
     it("can close cancel confirmation dialog and continue editing", async () => {

--- a/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.tsx
+++ b/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.tsx
@@ -149,7 +149,7 @@ function EditorControls(): ReactElement {
     const onCancelClick = useEvent(() => {
         if (!context.didEdit) {
             LOG.debug(
-                "Skipping cancel conformation dialog because the user did not edit the feature"
+                "Skipping cancel confirmation dialog because the user did not edit the feature"
             );
             onConfirmCancelClick();
         } else {

--- a/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.tsx
+++ b/src/packages/feature-editing/implementation/components/property-editor/PropertyEditor.tsx
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Flex, useDisclosure } from "@chakra-ui/react";
+import { createLogger } from "@open-pioneer/core";
 import { useEvent } from "@open-pioneer/react-utils";
 import { useReactiveSnapshot } from "@open-pioneer/reactivity";
-import { useCallback, useMemo, type ReactElement } from "react";
+import { sourceId } from "open-pioneer:source-info";
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 import { FeatureEditorProps, FormTemplateContext } from "../../../api/editor/editor";
 import { CreationStep, UpdateStep } from "../../../api/model/EditingStep";
 import { FeatureTemplate, FormTemplate } from "../../../api/model/FeatureTemplate";
 import {
-    DeclarativeFormContext,
+    AnyPropertyFormContext,
     CustomFormContextImpl,
+    DeclarativeFormContext,
     FormContext
 } from "../../context/PropertyFormContext";
 import { usePropertyFormContext } from "../../context/usePropertyFormContext";
@@ -21,6 +24,8 @@ import { DeleteConfirmationDialog } from "./DeleteConfirmationDialog";
 import { PropertyField } from "./PropertyField";
 import { PropertyForm } from "./PropertyForm";
 
+const LOG = createLogger(sourceId);
+
 export function PropertyEditor(props: {
     editingStep: CreationStep | UpdateStep;
     callbacks: EditingCallbacks;
@@ -30,16 +35,23 @@ export function PropertyEditor(props: {
     const { editingStep, callbacks, templates, resolveFormTemplate } = props;
     const formTemplate = useFormTemplate(templates, resolveFormTemplate, editingStep);
 
-    const context = useMemo(() => {
+    const [context, setContext] = useState<AnyPropertyFormContext>();
+    useEffect(() => {
         if (!formTemplate) {
             return undefined;
         }
 
+        let ctx;
         if (formTemplate.kind === "declarative") {
-            return new DeclarativeFormContext(editingStep, callbacks, formTemplate);
+            ctx = new DeclarativeFormContext(editingStep, callbacks, formTemplate);
         } else {
-            return new CustomFormContextImpl(editingStep, callbacks, formTemplate);
+            ctx = new CustomFormContextImpl(editingStep, callbacks, formTemplate);
         }
+        setContext(ctx);
+        return () => {
+            ctx.destroy();
+            setContext(undefined);
+        };
     }, [formTemplate, editingStep, callbacks]);
 
     return (
@@ -134,6 +146,17 @@ function EditorControls(): ReactElement {
         closeCancelConfirmationDialog();
     });
 
+    const onCancelClick = useEvent(() => {
+        if (!context.didEdit) {
+            LOG.debug(
+                "Skipping cancel conformation dialog because the user did not edit the feature"
+            );
+            onConfirmCancelClick();
+        } else {
+            openCancelDialog();
+        }
+    });
+
     return (
         <>
             <ButtonRow
@@ -141,7 +164,7 @@ function EditorControls(): ReactElement {
                 showDeleteButton={context.mode === "update"}
                 onSave={onSaveClick}
                 onDelete={openDeleteDialog}
-                onCancel={openCancelDialog}
+                onCancel={onCancelClick}
             />
             <DeleteConfirmationDialog
                 isOpen={deleteDialogIsOpen}

--- a/src/packages/feature-editing/implementation/context/PropertyFormContext.ts
+++ b/src/packages/feature-editing/implementation/context/PropertyFormContext.ts
@@ -6,10 +6,14 @@ import {
     reactive,
     reactiveMap,
     ReadonlyReactive,
+    watchValue,
     type ReactiveMap
 } from "@conterra/reactivity-core";
+import { destroyResources, Resource, createLogger, shallowEqual } from "@open-pioneer/core";
 import type { Layer } from "@open-pioneer/map";
 import type { Feature } from "ol";
+import { unByKey } from "ol/Observable";
+import { sourceId } from "open-pioneer:source-info";
 import { createContext } from "react";
 import type { CustomFormContext, Mode } from "../../api/editor/context";
 import { PropertyFunctionOr } from "../../api/fields/BaseFieldConfig";
@@ -22,11 +26,15 @@ import type {
 } from "../../api/model/FeatureTemplate";
 import { EditingCallbacks } from "../editor/useEditingCallbacks";
 
-export abstract class BaseFormContext {
+const LOG = createLogger(sourceId);
+
+export abstract class BaseFormContext implements Resource {
     readonly #propertiesMap: ReactiveMap<string, unknown>;
     readonly #modificationStep: ModificationStep;
     readonly #formTemplate: FormTemplate;
     readonly #propsAsObject: ReadonlyReactive<Record<string, unknown>>;
+    readonly #didEdit = reactive(false);
+    #watchEditResources: Resource[] = [];
 
     readonly callbacks: EditingCallbacks;
 
@@ -41,11 +49,25 @@ export abstract class BaseFormContext {
 
         const entries = BaseFormContext.#getPropertyEntries(modificationStep.feature);
         this.#propertiesMap = reactiveMap(entries);
-        this.#propsAsObject = computed(() => {
-            const entries = this.properties.entries();
-            const object = Object.fromEntries(entries);
-            return object;
-        });
+        this.#propsAsObject = computed(
+            () => {
+                const entries = this.properties.entries();
+                const object = Object.fromEntries(entries);
+                return object;
+            },
+            { equal: shallowEqual }
+        );
+
+        if (modificationStep.id === "creation") {
+            // The user did just draw the initial geometry; so we always have an "edit".
+            this.#didEdit.value = true;
+        } else if (modificationStep.id === "update") {
+            this.#watchForAnyEdit();
+        }
+    }
+
+    destroy() {
+        destroyResources(this.#watchEditResources);
     }
 
     getPropertiesAsObject(): Record<string, unknown> {
@@ -62,6 +84,10 @@ export abstract class BaseFormContext {
 
     get editingStep(): ModificationStep {
         return this.#modificationStep;
+    }
+
+    get didEdit(): boolean {
+        return this.#didEdit.value;
     }
 
     get properties(): ReactiveMap<string, unknown> {
@@ -87,6 +113,39 @@ export abstract class BaseFormContext {
         const properties = feature.getProperties();
         const geometryName = feature.getGeometryName();
         return Object.entries(properties).filter(([key, _]) => key !== geometryName);
+    }
+
+    #watchForAnyEdit() {
+        const feature = this.#modificationStep.feature;
+        const geometry = feature.getGeometry();
+
+        const geometryChanged = () => {
+            LOG.debug("Geometry changed. The feature has been edited.");
+            this.#didEdit.value = true;
+            destroyResources(this.#watchEditResources);
+        };
+        const geometryKey1 = feature.on("change:geometry", geometryChanged);
+        const geometryKey2 = geometry?.on("change", geometryChanged);
+
+        this.#watchEditResources.push(
+            {
+                destroy() {
+                    unByKey(geometryKey1);
+                    geometryKey2 && unByKey(geometryKey2);
+                }
+            },
+            watchValue(
+                () => this.getPropertiesAsObject(),
+                (_props) => {
+                    LOG.debug("Properties changed. The feature has been edited.");
+                    this.#didEdit.value = true;
+                    destroyResources(this.#watchEditResources);
+                },
+                {
+                    dispatch: "sync"
+                }
+            )
+        );
     }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
     const devMode = mode === "development";
 
     // Allowed values are "DEBUG", "INFO", "WARN", "ERROR"
-    const logLevel = devMode ? "INFO" : "WARN";
+    const logLevel = devMode ? "DEBUG" : "WARN";
 
     return {
         root: resolve(import.meta.dirname, "src"),


### PR DESCRIPTION
Skips the cancel dialog in the _edit workflow_ (existing feature) when neither the geometry nor the feature properties have been edited.

Does not apply to the _create workflow_ because the user made edits by definition: they drew the geometry to enter the property form.